### PR TITLE
remove --bin from cargo new

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -13,7 +13,7 @@ Let’s write our first actix web application!
 Start by creating a new binary-based Cargo project and changing into the new directory:
 
 ```bash
-cargo new hello-world --bin
+cargo new hello-world
 cd hello-world
 ```
 


### PR DESCRIPTION
`cargo new` defaults to `--bin` since cargo 0.26