### PR TITLE
Update latest required Rust version

### DIFF
--- a/content/docs/whatis.md
+++ b/content/docs/whatis.md
@@ -23,5 +23,5 @@ server `actix-web` is powerful enough to provide HTTP 1 and HTTP 2 support as
 well as SSL/TLS.  This makes it useful for building small services ready for
 distribution.
 
-Most importantly: `actix-web` runs on Rust 1.24 or later and it works with
+Most importantly: `actix-web` runs on Rust 1.26 or later and it works with
 stable releases.


### PR DESCRIPTION
The readme file in https://github.com/actix/actix-web states that the oldest supported Rust version is 1.26.