### PR TITLE
Fix two typos in Basics/{Server, Extractors}.

### DIFF
--- a/content/docs/extractors.md
+++ b/content/docs/extractors.md
@@ -184,7 +184,7 @@ When you register a handler using `Route::with()`, it returns a configuration in
 a *Json* extractor it returns a *JsonConfig*. You can configure the maximum size of the json
 payload as well as a custom error handler function.
 
-The following example limits the size of the payload to 4kb and uses a custom error hander.
+The following example limits the size of the payload to 4kb and uses a custom error handler.
 
 ```rust
 #[macro_use] extern crate serde_derive;

--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -15,7 +15,7 @@ application factory must have `Send` + `Sync` boundaries. More about that in the
 
 To bind to a specific socket address,
 [`bind()`](../../actix-web/actix_web/server/struct.HttpServer.html#method.bind)
-must be used, and it may be called multiple times. To bind ssl socket
+must be used, and it may be called multiple times. To bind ssl socket,
 [`bind_ssl()`](../../actix-web/actix_web/server/struct.HttpServer.html#method.bind_ssl)
 or [`bind_tls()`](../../actix-web/actix_web/server/struct.HttpServer.html#method.bind_tls)
 should be used. To start the http server, one of the start methods.


### PR DESCRIPTION
As is clearly presented in the diff. : )