### PR TITLE
Update first testing example

### DIFF
--- a/content/docs/testing.md
+++ b/content/docs/testing.md
@@ -31,12 +31,12 @@ fn index(req: &HttpRequest) -> HttpResponse {
 
 fn main() {
     let resp = test::TestRequest::with_header("content-type", "text/plain")
-        .run(index)
+        .run(&index)
         .unwrap();
     assert_eq!(resp.status(), http::StatusCode::OK);
 
     let resp = test::TestRequest::default()
-        .run(index)
+        .run(&index)
         .unwrap();
     assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
The example provided does not compile, this change allows it to.

Without this change:

```sh
error[E0308]: mismatched types
  --> src/test.rs:15:14
   |
15 |         .run(index)
   |              ^^^^^
   |              |
   |              expected reference, found fn item
   |              help: consider borrowing here: `&index`
   |
   = note: expected type `&_`
              found type `for<'r> fn(&'r actix_web::HttpRequest) -> actix_web::HttpResponse {test::index}`

error[E0308]: mismatched types
  --> src/test.rs:20:14
   |
20 |         .run(index)
   |              ^^^^^
   |              |
   |              expected reference, found fn item
   |              help: consider borrowing here: `&index`
   |
   = note: expected type `&_`
              found type `for<'r> fn(&'r actix_web::HttpRequest) -> actix_web::HttpResponse {test::index}`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0308`.
```