### PR TITLE
Fixed broken links to API docs

### DIFF
--- a/content/docs/application.md
+++ b/content/docs/application.md
@@ -71,7 +71,7 @@ When the app is initialized it needs to be passed the initial state:
 
 Combining multiple applications with different state is possible as well.
 
-[server::new](https://docs.rs/actix-web/*/actix_web/server/fn.new.html) requires the handler to have a single type. 
+[server::new](https://docs.rs/actix-web/*/actix_web/server/fn.new.html) requires the handler to have a single type.
 
 This limitation can easily be overcome with the [App::boxed](https://docs.rs/actix-web/*/actix_web/struct.App.html#method.boxed) method, which converts an App into a boxed trait object.
 
@@ -99,13 +99,13 @@ it will generate a URL with that same path.
 
 You can think of a predicate as a simple function that accepts a *request* object reference
 and returns *true* or *false*. Formally, a predicate is any object that implements the
-[`Predicate`](../actix_web/pred/trait.Predicate.html) trait. Actix provides
+[`Predicate`](../../actix-web/actix_web/pred/trait.Predicate.html) trait. Actix provides
 several predicates, you can check
 [functions section](../../actix-web/actix_web/pred/index.html#functions) of api docs.
 
-Any of this predicates could be used 
-with [`App::filter()`](../actix_web/struct.App.html#method.filter) method. One of the
-provided predicates is [`Host`](../actix_web/pred/fn.Host.html), it can be used
+Any of this predicates could be used
+with [`App::filter()`](../../actix-web/actix_web/struct.App.html#method.filter) method. One of the
+provided predicates is [`Host`](../../actix-web/actix_web/pred/fn.Host.html), it can be used
 as application's filter based on request's host information.
 
 {{< include-example example="application" file="vh.rs" section="vh" >}}

--- a/content/docs/url-dispatch.md
+++ b/content/docs/url-dispatch.md
@@ -265,7 +265,7 @@ A scoped layout of these paths would appear as follows
 
 {{< include-example example="url-dispatch" file="scope.rs" section="scope" >}}
 
-A *scoped* path can contain variable path segments as resources. Consistent with 
+A *scoped* path can contain variable path segments as resources. Consistent with
 unscoped paths.
 
 You can get variable path segments from `HttpRequest::match_info()`.
@@ -274,9 +274,9 @@ You can get variable path segments from `HttpRequest::match_info()`.
 # Match information
 
 All values representing matched path segments are available in
-[`HttpRequest::match_info`](../actix_web/struct.HttpRequest.html#method.match_info).
+[`HttpRequest::match_info`](../../actix-web/actix_web/struct.HttpRequest.html#method.match_info).
 Specific values can be retrieved with
-[`Params::get()`](../actix_web/dev/struct.Params.html#method.get).
+[`Params::get()`](../../actix-web/actix_web/dev/struct.Params.html#method.get).
 
 Any matched parameter can be deserialized into a specific type if the type
 implements the `FromParam` trait. For example most standard integer types
@@ -403,7 +403,7 @@ it will generate a URL with that same path.
 
 You can think of a predicate as a simple function that accepts a *request* object reference
 and returns *true* or *false*. Formally, a predicate is any object that implements the
-[`Predicate`](../actix_web/pred/trait.Predicate.html) trait. Actix provides
+[`Predicate`](../../actix-web/actix_web/pred/trait.Predicate.html) trait. Actix provides
 several predicates, you can check
 [functions section](../../actix-web/actix_web/pred/index.html#functions) of api docs.
 


### PR DESCRIPTION
Fixed a few broken links on the Application and URL Dispatch page. These do not conflict with, nor overlap with the changes in #46.