### PR TITLE
Update index page's title

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,3 +1,3 @@
 ---
-title: Welcome
+title: Actix - Actor System and Web Framework for Rust
 ---


### PR DESCRIPTION
Currently the title is "Welcome", which is not ideal if you have many tabs open (even more so if favicons are disabled e.g. in Safari):

<img width="225" alt="screen shot 2018-10-09 at 12 01 01" src="https://user-images.githubusercontent.com/28710/46658508-8a097a80-cbbb-11e8-9859-36179835d58c.png">

