### PR TITLE
Fixed Either sample code

### DIFF
--- a/content/docs/handlers.md
+++ b/content/docs/handlers.md
@@ -278,7 +278,7 @@ use actix_web::{Either, Error, HttpResponse};
 
 type RegisterResult = Either<HttpResponse, Box<Future<Item=HttpResponse, Error=Error>>>;
 
-fn index(req: &HttpRequest) -> impl Responder {
+fn index(req: &HttpRequest) -> RegisterResult {
     if is_a_variant() { // <- choose variant A
         Either::A(
             HttpResponse::BadRequest().body("Bad data"))


### PR DESCRIPTION
The sample code of Handlers Either's return type will cause a problem like 
```
error[E0282]: type annotations needed
  --> src/main.rs:34:13
   |
34 |             result(Ok(HttpResponse::Ok()
   |             ^^^^^^ cannot infer type for `E`
```
This can be fixed by change the return type of `fn index` from `impl Responder` to `RegisterResult`.