### PR TITLE
One more grammatical improvement

### DIFF
--- a/content/docs/url-dispatch.md
+++ b/content/docs/url-dispatch.md
@@ -352,8 +352,8 @@ for URL generation purposes only and are never considered for matching at reques
 
 By normalizing it means:
 
-* Add a trailing slash to the path.
-* Double slashes are replaced by one.
+* To add a trailing slash to the path.
+* To replace multiple slashes with one.
 
 The handler returns as soon as it finds a path that resolves
 correctly. The order if all enable is 1) merge, 2) both merge and append


### PR DESCRIPTION
Also changed "double" to "multiple" because this feature can replace _more than_ two slashes with one  as well.