### PR TITLE
Update docs and examples to consistently use port 8080

### DIFF
--- a/content/docs/autoreload.md
+++ b/content/docs/autoreload.md
@@ -61,7 +61,7 @@ fn main() {
     server = if let Some(l) = listenfd.take_tcp_listener(0).unwrap() {
         server.listen(l)
     } else {
-        server.bind("127.0.0.1:3000").unwrap()
+        server.bind("127.0.0.1:8080").unwrap()
     };
 
     server.run();
@@ -73,5 +73,5 @@ fn main() {
 To now run the development server invoke this command:
 
 ```
-systemfd --no-pid -s http::3000 -- cargo watch -x run
+systemfd --no-pid -s http::8080 -- cargo watch -x run
 ```

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -44,7 +44,7 @@ function is shortcut for `HttpServer::new`:
 {{< include-example example="getting-started" section="main" >}}
 
 That's it! Now, compile and run the program with `cargo run`.
-Head over to ``http://localhost:8088/`` to see the results.
+Head over to ``http://localhost:8080/`` to see the results.
 
 If you want you can have an automatic reloading server during development
 that recompiles on demand.  To see how this can be accomplished have a look

--- a/content/docs/handlers.md
+++ b/content/docs/handlers.md
@@ -118,10 +118,10 @@ fn main() {
             App::new()
                 .resource("/", move |r| r.h(MyHandler(cloned)))
         })
-        .bind("127.0.0.1:8088").unwrap()
+        .bind("127.0.0.1:8080").unwrap()
         .start();
 
-    println!("Started http server: 127.0.0.1:8088");
+    println!("Started http server: 127.0.0.1:8080");
     let _ = sys.run();
 }
 ```
@@ -175,10 +175,10 @@ fn main() {
     server::new(
         || App::new()
             .resource("/", |r| r.method(http::Method::GET).f(index)))
-        .bind("127.0.0.1:8088").unwrap()
+        .bind("127.0.0.1:8080").unwrap()
         .start();
 
-    println!("Started http server: 127.0.0.1:8088");
+    println!("Started http server: 127.0.0.1:8080");
     let _ = sys.run();
 }
 ```

--- a/examples/getting-started/src/main.rs
+++ b/examples/getting-started/src/main.rs
@@ -9,7 +9,7 @@ fn index(_req: &HttpRequest) -> &'static str {
 // <main>
 fn main() {
     server::new(|| App::new().resource("/", |r| r.f(index)))
-        .bind("127.0.0.1:8088")
+        .bind("127.0.0.1:8080")
         .unwrap()
         .run();
 }


### PR DESCRIPTION
Hello,

When going through the documentation, I was tripped up for a second on the port changing from `8088` in the getting started section to `8080` in the next section. I did a global search for `8088` and `8080` and it seems like `8080` is used much more often. I see no reason not to be consistently using `8080` across the documentation. 

Let me know if I'm missing something though.