### PR TITLE
Fix guard warning in Sentry initialization snippet

### DIFF
--- a/content/docs/sentry.md
+++ b/content/docs/sentry.md
@@ -29,7 +29,7 @@ use sentry_actix::SentryMiddleware;
 use std::env;
 
 fn main() {
-    sentry::init("SENTRY_DSN_GOES_HERE");
+    let _guard = sentry::init("SENTRY_DSN_GOES_HERE");
     env::set_var("RUST_BACKTRACE", "1");
     sentry::integrations::panic::register_panic_handler();
 


### PR DESCRIPTION
Prevents this warning to appear:

```
warning: unused `sentry::internals::ClientInitGuard` that must be used
  --> src/main.rs:42:5
   |
42 |     sentry::init(settings.sentry_dsn.clone());
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_must_use)] on by default
   = note: when the init guard is dropped the transport will be shut down and no further events can be sent.  If you do want to ignore this use mem::forget on it.


``` 