### PR TITLE
add comma to getting-started

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -46,6 +46,6 @@ function is shortcut for `HttpServer::new`:
 That's it! Now, compile and run the program with `cargo run`.
 Head over to ``http://localhost:8088/`` to see the results.
 
-If you want you can have an automatic reloading server during development
+If you want, you can have an automatic reloading server during development
 that recompiles on demand.  To see how this can be accomplished have a look
 at the [autoreload pattern](../autoreload/).


### PR DESCRIPTION
I got tripped up by the penultimate sentence, partially because it's missing a comma.