### PR TITLE
Fix a slight typo

### DIFF
--- a/content/docs/application.md
+++ b/content/docs/application.md
@@ -60,7 +60,7 @@ When the app is initialized it needs to be passed the initial state:
 > **Note**: http server accepts an application factory rather than an application
 > instance. Http server constructs an application instance for each thread, thus application state
 > must be constructed multiple times. If you want to share state between different threads, a
-> shared object should be used, e.g. `Arc`. There is also an [Example](https://github.com/actix/examples/blob/master/state/src/main.rs) use `Arc` for this. Application state does not need to be `Send` and `Sync`,
+> shared object should be used, e.g. `Arc`. There is also an [Example](https://github.com/actix/examples/blob/master/state/src/main.rs) using `Arc` for this. Application state does not need to be `Send` and `Sync`,
 > but the application factory must be `Send` + `Sync`. 
 >
 


### PR DESCRIPTION
There was a "use" which should be "using".