### PR TITLE
Adjust the integration tests documentation

### DIFF
--- a/content/docs/testing.md
+++ b/content/docs/testing.md
@@ -76,8 +76,9 @@ First, define the method that will be configuring an `App` in the place that can
 
 ```rust
 // file src/lib.rs
-pub fn config_app<P>(cfg: &mut web::RouterConfig<P>)
-    where P: Stream<Item=Bytes, Error=error::PayloadError> + 'static {
+use actix_web::{HttpResponse, web};
+
+pub fn config_app(cfg: &mut web::RouterConfig) {
     cfg.service(web::resource("/test").to(|| HttpResponse::Ok()
         .content_type("test/plain").body("This is a test response")));
 }


### PR DESCRIPTION
Hi.
As promised in Gitter, submitting a new IT test documentation draft.

I've used the following crates:

```
actix-web="1.0.0-alpha.5"
actix-service="0.3"
actix-rt = "0.2"

futures = "0.1"
```

and the app code can be found in the diff.

A few things I've noticed when composed the documentation:
* `app.call` code that I use in the integration tests requires the `use actix_service::Service;` trait import that does not exist in the `actix-web` crate and requires the `actix-service` crate to be added into the project.

IMO, this is rather weird from the user's point of view, can we do something about it?
Also https://crates.io/crates/actix-service lacks the general crate description, it's rather hard to understand what is this crate designed for.

* When I needed to extract the http response body, I was forced to write the`extract_response_body` method. This operation seems to be rather regular to use in tests and my code seems rather clumsy to write every time in every project. Is there a shorthand method that I might have missed?

* Every time I run `cargo test`, I get 
```thread '<unnamed>' panicked at 'use of std::thread::current() is not possible after the thread's local data has been destroyed', src/libcore/option.rs:1038:5```

and even though the tests are shown as passed, the `cargo test` process exists with an error code.
This means that if I run those in the CI, it will fail.
How can I fix it?