### PR TITLE
Removes global 1.0 warning and only adds it to specific pages.

### DIFF
--- a/content/docs/databases.md
+++ b/content/docs/databases.md
@@ -6,6 +6,14 @@ weight: 1010
 
 # Diesel
 
+{{% alert %}}
+NOTE: The `actix-web` 1.0 version of this section is still
+[being updated](https://github.com/cldershem/actix-website/tree/update1.0-db). Checkout
+this [example](https://github.com/actix/examples/tree/master/async_db) until then.
+{{% /alert %}}
+
+[being updated](https://github.com/cldershem/actix-website/tree/update1.0-db).
+
 At the moment, Diesel 1.0 does not support asynchronous operations,
 but it's possible to use the `actix` synchronous actor system as a database interface api.
 

--- a/content/docs/sentry.md
+++ b/content/docs/sentry.md
@@ -6,6 +6,11 @@ weight: 1020
 
 # Sentry Crash Reporting
 
+{{% alert %}}
+NOTE: Sentry currently does not work with `actix-web` 1.0. Please checkout this
+[issue](https://github.com/getsentry/sentry-rust/issues/143) for more details.
+{{% /alert %}}
+
 [Sentry][sentrysite] is a crash reporting system that supports the failure crate which
 is the base of the actix error reporting.  With a middleware it's possible to
 automatically report server errors to Sentry.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,12 +54,4 @@
           </ul>
         </div>
       </nav>
-      <div id="heads-up" class="alert alert-info" role="alert">
-        Looking for actix-web 1.0 docs? This book is currently
-        <a href="https://github.com/actix/actix-website/pull/90" class="alert-link">out of date</a>.
-        In the meantime checkout the
-        <a href="https://docs.rs/actix-web/" class="alert-link">API docs</a>
-        and the
-        <a href="https://github.com/actix/examples" class="alert-link">examples repo</a>.
-      </div>
     </header>

--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,0 +1,3 @@
+<div class="alert alert-info" role="alert">
+  {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
This PR removes the global "Docs are out of sync" warning and only adds it to specific pages, mainly DB and Sentry.