### PR TITLE
Correct demo code

### DIFF
--- a/content/docs/handlers.md
+++ b/content/docs/handlers.md
@@ -38,7 +38,7 @@ complex types are involved.
 
 ```rust
 fn index(_req: HttpRequest) -> impl Responder {
-    Bytes::from_static("Hello world!")
+    Bytes::from_static(b"Hello world!")
 }
 ```
 


### PR DESCRIPTION
Add a `b` before `"Hello, world"`