### PR TITLE
Fix plural to singular dependency

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -17,7 +17,7 @@ cargo new hello-world
 cd hello-world
 ```
 
-Now, add `actix-web` as dependencies of your project by ensuring your `Cargo.toml`
+Now, add `actix-web` as a dependency of your project by ensuring your `Cargo.toml`
 contains the following:
 
 ```ini


### PR DESCRIPTION
This used to be plural because it used to be both actix and actix-web but now it's just actix-web.