### PR TITLE
Make sure app_mutable example works out of box

### DIFF
--- a/examples/application/src/state.rs
+++ b/examples/application/src/state.rs
@@ -33,9 +33,15 @@ fn _main() {
         counter: Mutex::new(0),
     });
 
-    App::new()
-        .register_data(counter.clone()) // <- register the created data
-        .route("/", web::get().to(index));
+    HttpServer::new(move || { // move counter into the closure
+        App::new()
+            .register_data(counter.clone()) // <- register the created data
+            .route("/", web::get().to(_index))
+    })
+        .bind("127.0.0.1:8088")
+        .unwrap()
+        .run()
+        .unwrap();
 }
 // </make_app_mutable>
 


### PR DESCRIPTION
The page which refers make_app_mutable section: https://actix.rs/docs/application/ 
Although the original example compiled, I found it a bit incomplete as it didn't really start the server. As a beginner, I first tried to reuse original `main()` example and ran into lifetime issue with counter instance. Took me a bit to figure "ahha sure, I need to move it in."