### PR TITLE
fix minor typo in output of extractors example

### DIFF
--- a/examples/extractors/src/multiple.rs
+++ b/examples/extractors/src/multiple.rs
@@ -9,7 +9,7 @@ struct Info {
 
 fn index((path, query): (web::Path<(u32, String)>, web::Query<Info>)) -> String {
     format!(
-        "Welcome {}, friend {}, useri {}!",
+        "Welcome {}, friend {}, userid {}!",
         query.username, path.1, path.0
     )
 }


### PR DESCRIPTION
this has no effect on the actual functionality, it just fixes a typo
which was hard to overlook :)