### PR TITLE
A small fix for the example set up of SSL

### DIFF
--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -55,6 +55,7 @@ for `rust-tls` integration and `ssl` is for `openssl`.
 ```toml
 [dependencies]
 actix-web = { version = "{{< actix-version "actix-web" >}}", features = ["ssl"] }
+openssl = { version="0.10" }
 ```
 
 {{< include-example example="server" file="ssl.rs" section="ssl" >}}


### PR DESCRIPTION
* openssl is missing in the dependencies