### PR TITLE
Fixing tokio.rs link

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -13,7 +13,7 @@ Actix is your door to developing web services with Rust and this documentation
 is going to guide you.
 
 This documentation currently covers mostly the `actix-web` part which is the high level
-web framework previously built on top of the `actix` actor framework and the [Tokio][tokio]
+web framework previously built on top of the `actix` actor framework and the [Tokio](https://tokio.rs)
 async IO system.  This is the part that is from an API stability point of view the most stable.
 
 If you haven't used `actix-web` yet it's best to start with the [getting started


### PR DESCRIPTION
Current link try to open `https://actix.rs/docs/(https://tokio.rs/)`.