### PR TITLE
fixed argument order and format of new method of Files.

### DIFF
--- a/examples/static-files/src/configuration_two.rs
+++ b/examples/static-files/src/configuration_two.rs
@@ -5,7 +5,8 @@ use actix_web::{App, HttpServer};
 pub fn main() {
     HttpServer::new(|| {
         App::new().service(
-            fs::Files::new("/static", ".")
+            // fs::Files::new("/static", ".")
+            fs::Files::new("", "static")
                 .show_files_listing()
                 .use_last_modified(true),
         )

--- a/examples/static-files/src/directory.rs
+++ b/examples/static-files/src/directory.rs
@@ -4,7 +4,8 @@ use actix_web::{App, HttpServer};
 
 pub fn main() {
     HttpServer::new(|| {
-        App::new().service(fs::Files::new("/static", ".").show_files_listing())
+        // App::new().service(fs::Files::new("/static", ".").show_files_listing())
+        App::new().service(fs::Files::new("", "static").show_files_listing())
     })
     .bind("127.0.0.1:8088")
     .unwrap()


### PR DESCRIPTION
I guess the example source files might be some kind of mistake.

I executed original source and accessed from Firefox, but none of contents was displayed.
After checking argument order of new method of FIles and re-execute, contents of specified directory were displayed.