### PR TITLE
Show quick install instructions on home page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,24 +4,17 @@
   <div class="jumbotron">
     <div class="actix-jumbotron">
       <img src="/img/logo-large.png" class="align-middle actix-logo" alt="">
-      <p class="lead">rust's powerful actor system and most fun web framework
+      <p class="lead">
+        rust's powerful actor system and most fun web framework
       </p>
+      <a href="/docs/installation/"
+         class="btn btn-secondary install actix-jumbotron-install">
+        Install
+      </a>
     </div>
   </div>
 
   <div class="container actix-home">
-    <div class="actix-content actix-quick-install">
-      <h4>Quick Install</h4>
-      {{ highlight `# In your Cargo.toml
-[dependencies]
-actix-web = "2.0"` "toml" "" }}
-      <small>
-        View <a href="/docs/installation/">installation page</a>
-        for advanced instructions.
-      </small>
-    </div>
-
-    <h4>Features</h4>
     <div class="row">
       <div class="col-md-4">
         <div class="actix-features">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,7 @@
         rust's powerful actor system and most fun web framework
       </p>
       <a href="/docs/installation/"
-         class="btn btn-secondary install actix-jumbotron-install">
+         class="btn btn-secondary actix-jumbotron-install">
         Install
       </a>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,9 @@
   <div class="container actix-home">
     <div class="actix-content actix-quick-install">
       <h4>Quick Install</h4>
-      {{ highlight `cargo add actix-web` "shell" "" }}
+      {{ highlight `# In your Cargo.toml
+[dependencies]
+actix-web = "2.0"` "toml" "" }}
       <small>
         View <a href="/docs/installation/">installation page</a>
         for advanced instructions.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,6 +10,16 @@
   </div>
 
   <div class="container actix-home">
+    <div class="actix-content actix-quick-install">
+      <h4>Quick Install</h4>
+      {{ highlight `cargo add actix-web` "shell" "" }}
+      <small>
+        View <a href="/docs/installation/">installation page</a>
+        for advanced instructions.
+      </small>
+    </div>
+
+    <h4>Features</h4>
     <div class="row">
       <div class="col-md-4">
         <div class="actix-features">

--- a/static/css/actix.css
+++ b/static/css/actix.css
@@ -327,11 +327,10 @@ img {
  *
  */
 
-.actix-quick-install {
-  margin-bottom: 2rem;
-}
-.actix-quick-install .chroma {
-  margin-bottom: 0;
+.actix-jumbotron-install {
+  min-width: 120px;
+  margin-top: 2rem;
+  display: inline-block;
 }
 
 .actix-features h2 {

--- a/static/css/actix.css
+++ b/static/css/actix.css
@@ -327,6 +327,13 @@ img {
  *
  */
 
+.actix-quick-install {
+  margin-bottom: 2rem;
+}
+.actix-quick-install .chroma {
+  margin-bottom: 0;
+}
+
 .actix-features h2 {
   font-size: 1.5rem;
   margin-top: 2.25rem;


### PR DESCRIPTION
### Reasons for the change:
- There is no clear CTA for installation on the homepage. One has to go via the docs.
- One cannot map the name to a cargo package because `actix` the framework is different from `actix-web` which this website covers.

### How does it look after the change
See the screenshot below and another alternative [in this comment](https://github.com/actix/actix-website/pull/134#issuecomment-569649913)

![actix-2](https://user-images.githubusercontent.com/4113784/71579390-4f726180-2b22-11ea-92ab-300c52924a2d.png)

