### PR TITLE
Suppress some warnings on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       script: ./hugo
     - env:
       - TASK=check
+      - RUSTFLAGS="-A dead-code -A unused-variables"
       language: rust
       script: cd examples; cargo check; cargo test
 

--- a/examples/requests/src/streaming.rs
+++ b/examples/requests/src/streaming.rs
@@ -1,6 +1,6 @@
 // <streaming>
-use actix_web::{error, web, Error, HttpResponse};
-use futures::{Future, Stream, StreamExt};
+use actix_web::{web, Error, HttpResponse};
+use futures::StreamExt;
 
 async fn index(mut body: web::Payload) -> Result<HttpResponse, Error> {
     let mut bytes = web::BytesMut::new();

--- a/examples/responses/src/chunked.rs
+++ b/examples/responses/src/chunked.rs
@@ -1,5 +1,5 @@
 // <chunked>
-use actix_web::{web, HttpRequest, HttpResponse, Error};
+use actix_web::{HttpRequest, HttpResponse, Error};
 use bytes::Bytes;
 use futures::future::ok;
 use futures::stream::once;


### PR DESCRIPTION
It's annoying and useless on CI (and they are just examples).