### PR TITLE
Fix nextup links

### DIFF
--- a/content/docs/conn_lifecycle.md
+++ b/content/docs/conn_lifecycle.md
@@ -1,13 +1,13 @@
 ---
 title: Connection Lifecycle
 menu: docs_architecture
-weight: 20
+weight: 1030
 ---
 
 
 # Architecture overview
 
-After Server has started listening to all sockets, [`Accept`][Accept] and [`Worker`][Worker] are two main loops responsible for processing incoming client connections. 
+After Server has started listening to all sockets, [`Accept`][Accept] and [`Worker`][Worker] are two main loops responsible for processing incoming client connections.
 
 Once connection accepted Application level protocol processing happens in a protocol specific [`Dispatcher`][Dispatcher] loop spawned from [`Worker`][Worker].
 
@@ -19,19 +19,19 @@ Once connection accepted Application level protocol processing happens in a prot
 
 ![](/img/diagrams/connection_accept.svg)
 
-Most of code implementation resides in [`actix-server`][server] crate for struct [`Accept`][Accept]. 
+Most of code implementation resides in [`actix-server`][server] crate for struct [`Accept`][Accept].
 
 ## Worker loop in more detail
 
 ![](/img/diagrams/connection_worker.svg)
 
-Most of code implementation resides in [`actix-server`][server] crate for struct [`Worker`][Worker]. 
+Most of code implementation resides in [`actix-server`][server] crate for struct [`Worker`][Worker].
 
 ## Request loop roughly
 
 ![](/img/diagrams/connection_request.svg)
 
-Most of code implementation for request loop resides in [`actix-web`][web] and [`actix-http`][http] crates. 
+Most of code implementation for request loop resides in [`actix-web`][web] and [`actix-http`][http] crates.
 
 
 [server]: https://crates.io/crates/actix-server

--- a/content/docs/http_server_init.md
+++ b/content/docs/http_server_init.md
@@ -1,7 +1,7 @@
 ---
 title: Http Server Initialization
 menu: docs_architecture
-weight: 10
+weight: 1020
 ---
 
 ## Architecture overview

--- a/content/docs/testing.md
+++ b/content/docs/testing.md
@@ -1,7 +1,7 @@
 ---
 title: Testing
 menu: docs_advanced
-weight: 210
+weight: 215
 ---
 
 # Testing

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -103,10 +103,18 @@
         <div class="github-edit">
             <a class="fa fa-github" href="https://github.com/actix/actix-website/tree/master/content/{{ .File.Path }}"> Edit on GitHub</a>
         </div>
-        <!-- Yes, we have to use *Prev* to get the next content, because the
-        weights are sorted inversely to how they are actually displayed... -->
-        {{ with .PrevInSection }}<div class="actix-next"><b>Next up</b>: <a href = {{ .URL }}>{{ end }}
-        {{ with .PrevInSection }} {{ .Title }}</a></div>{{ end }}
+
+        {{ if eq (len .Pages) 0 }}
+            {{ .Scratch.Set "Docs" .Parent.Pages.ByWeight }}
+        {{ else }}
+            {{ .Scratch.Set "Docs" .Pages.ByWeight }}
+        {{ end }}
+
+        {{ .Scratch.Set "CurrentWeight" .Weight }}
+
+        {{ range first 1 (where (.Scratch.Get "Docs") ".Weight" ">" (.Scratch.Get "CurrentWeight")) }}
+            <div class="actix-next"><b>Next up</b>: <a href = {{ .URL }}>{{ .Title }}</a></div>
+        {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Hi,

This PR fixes #152 — the missing nextup link on the docs welcome page — as well as the unmentioned missing link at /docs/databases.