### PR TITLE
Fix Hugo warnings

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-{{ $currentURL := .URL }}
+{{ $currentURL := .RelPermalink }}
 
 <div class="actix-pageheader">
   <div class="container">

--- a/layouts/code/baseof.html
+++ b/layouts/code/baseof.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-{{ $currentURL := .URL }}
+{{ $currentURL := .RelPermalink }}
 
 <div class="actix-pageheader">
   <div class="container">

--- a/layouts/community/baseof.html
+++ b/layouts/community/baseof.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-{{ $currentURL := .URL }}
+{{ $currentURL := .RelPermalink }}
 
 <div class="actix-pageheader">
   <div class="container">

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-{{ $currentURL := .URL }}
+{{ $currentURL := .RelPermalink }}
 
 <div class="actix-pageheader">
   <div class="container">
@@ -113,7 +113,7 @@
         {{ .Scratch.Set "CurrentWeight" .Weight }}
 
         {{ range first 1 (where (.Scratch.Get "Docs") ".Weight" ">" (.Scratch.Get "CurrentWeight")) }}
-            <div class="actix-next"><b>Next up</b>: <a href = {{ .URL }}>{{ .Title }}</a></div>
+            <div class="actix-next"><b>Next up</b>: <a href = {{ .RelPermalink }}>{{ .Title }}</a></div>
         {{ end }}
       </div>
     </div>


### PR DESCRIPTION
Hugo says `Page.URL` is deprecated now.