### PR TITLE
static-files.md: fix typo

### DIFF
--- a/content/docs/static-files.md
+++ b/content/docs/static-files.md
@@ -31,7 +31,7 @@ index file. Use the [*Files::index_file()*][indexfile] method to configure this 
 
 `NamedFiles` can specify various options for serving files:
 
-- `set_content_dispostion` - function to be used for mapping file's mime to corresponding `Content-Disposition` type
+- `set_content_disposition` - function to be used for mapping file's mime to corresponding `Content-Disposition` type
 - `use_etag` - specifies whether `ETag` shall be calculated and included in headers.
 - `use_last_modified` - specifies whether file modified timestamp should be used and added to `Last-Modified` header.
 


### PR DESCRIPTION
I'm a new Rust programmer (though I've plenty of experience in other languages), and after a few smaller projects to get a feel for the language I've decided to build a simple web app in Rust as a slightly larger project.

To this end, I've been studying the actix docs closely - and after a false start I've managed to get it working.

However, when I got around to learning about static files, I found a typo. This PR fixes that typo :P