### PR TITLE
Fix logic bug in streaming request example

### DIFF
--- a/examples/requests/src/streaming.rs
+++ b/examples/requests/src/streaming.rs
@@ -5,10 +5,11 @@ use futures::StreamExt;
 async fn index(mut body: web::Payload) -> Result<HttpResponse, Error> {
     let mut bytes = web::BytesMut::new();
     while let Some(item) = body.next().await {
-        bytes.extend_from_slice(&item?);
+        let item = item?;
+        println!("Chunk: {:?}", &item);
+        bytes.extend_from_slice(&item);
     }
 
-    println!("Chunk: {:?}", bytes);
     Ok(HttpResponse::Ok().finish())
 }
 // </streaming>


### PR DESCRIPTION
Previously the example printed "Chunk: {}" once after the entire
response was received, but the accompanying text read "we read and print
the request payload chunk by chunk".

The example now prints every chunk as it was received.