### PR TITLE
Use RUST_LOG env var if set

### DIFF
--- a/examples/middleware/src/logger.rs
+++ b/examples/middleware/src/logger.rs
@@ -1,6 +1,5 @@
 // <logger>
 use actix_web::middleware::Logger;
-use env_logger;
 use env_logger::Env;
 
 #[actix_rt::main]

--- a/examples/middleware/src/logger.rs
+++ b/examples/middleware/src/logger.rs
@@ -1,13 +1,13 @@
 // <logger>
 use actix_web::middleware::Logger;
 use env_logger;
+use env_logger::Env;
 
 #[actix_rt::main]
 async fn main() -> std::io::Result<()> {
     use actix_web::{App, HttpServer};
 
-    std::env::set_var("RUST_LOG", "actix_web=info");
-    env_logger::init();
+    env_logger::from_env(Env::default().default_filter_or("info")).init();
 
     HttpServer::new(|| {
         App::new()


### PR DESCRIPTION
Based on an example in the `env_logger` documentation: <https://docs.rs/env_logger/0.7.1/env_logger/#specifying-defaults-for-environment-variables>

Fixes https://github.com/actix/actix-website/issues/162

This will allow the RUST_LOG enviroment variable to have effect. I changed the default value from `actix_web=info` to `info`, which gives more verbose output initially, but it also allows users' own logging statements to be printed immediately.