### PR TITLE
Update error_response of ResponseError

### DIFF
--- a/content/docs/errors.md
+++ b/content/docs/errors.md
@@ -16,7 +16,7 @@ If a handler returns an `Error` (referring to the [general Rust trait
 
 ```rust
 pub trait ResponseError {
-    fn error_response(&self) -> HttpResponse;
+    fn error_response(&self) -> Response<Body>;
     fn status_code(&self) -> StatusCode;
 }
 ```


### PR DESCRIPTION
```error_response``` does not return ```HttpResponse``` (causes error)
switching to return  ```Response<Body>``` works fine