### PR TITLE
fix function name in shared mutable state example

### DIFF
--- a/examples/application/src/state.rs
+++ b/examples/application/src/state.rs
@@ -29,7 +29,7 @@ async fn _index(data: web::Data<AppStateWithCounter>) -> String {
 
 // <make_app_mutable>
 #[actix_rt::main]
-async fn _main() -> std::io::Result<()> {
+async fn main() -> std::io::Result<()> {
     let counter = web::Data::new(AppStateWithCounter {
         counter: Mutex::new(0),
     });


### PR DESCRIPTION
I changed the `_main` function to `main` since it failed to compile.
I received this error:
```
error[E0601]: `main` function not found in crate `hello_world`
  --> src/main.rs:1:1
   |
1  | / use actix_web::{web, App, HttpServer};
2  | | use std::sync::Mutex;
3  | |
4  | | struct AppStateWithCounter {
...  |
30 | |     .await
31 | | }
   | |_^ consider adding a `main` function to `src/main.rs`

error: aborting due to previous error
```
I was following the [Shared Mutable State part of the docs](https://actix.rs/docs/application/#shared-mutable-state)