### PR TITLE
fix function name in shared mutable state example

### DIFF
--- a/content/docs/application.md
+++ b/content/docs/application.md
@@ -57,11 +57,11 @@ Internally, [`web::Data`][data] uses `Arc`. Thus, in order to avoid creating two
 
 In the following example, we will write an application with mutable, shared state. First, we define our state and create our handler:
 
-{{< include-example example="application" file="state.rs" section="setup_mutable" >}}
+{{< include-example example="application" file="mutable_state.rs" section="setup_mutable" >}}
 
 and register the data in an `App`:
 
-{{< include-example example="application" file="state.rs" section="make_app_mutable" >}}
+{{< include-example example="application" file="mutable_state.rs" section="make_app_mutable" >}}
 
 ## Using an Application Scope to Compose Applications
 

--- a/examples/application/src/mutable_state.rs
+++ b/examples/application/src/mutable_state.rs
@@ -1,0 +1,35 @@
+// <setup_mutable>
+use actix_web::{web, App, HttpServer};
+use std::sync::Mutex;
+
+struct AppStateWithCounter {
+    counter: Mutex<i32>, // <- Mutex is necessary to mutate safely across threads
+}
+
+async fn index(data: web::Data<AppStateWithCounter>) -> String {
+    let mut counter = data.counter.lock().unwrap(); // <- get counter's MutexGuard
+    *counter += 1; // <- access counter inside MutexGuard
+
+    format!("Request number: {}", counter) // <- response with count
+}
+// </setup_mutable>
+
+// <make_app_mutable>
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
+    let counter = web::Data::new(AppStateWithCounter {
+        counter: Mutex::new(0),
+    });
+
+    HttpServer::new(move || {
+        // move counter into the closure
+        App::new()
+            // Note: using app_data instead of data
+            .app_data(counter.clone()) // <- register the created data
+            .route("/", web::get().to(index))
+    })
+    .bind("127.0.0.1:8088")?
+    .run()
+    .await
+}
+// </make_app_mutable>

--- a/examples/application/src/state.rs
+++ b/examples/application/src/state.rs
@@ -14,39 +14,6 @@ async fn index(data: web::Data<AppState>) -> String {
 }
 // </setup>
 
-// <setup_mutable>
-struct AppStateWithCounter {
-    counter: Mutex<i32>, // <- Mutex is necessary to mutate safely across threads
-}
-
-async fn _index(data: web::Data<AppStateWithCounter>) -> String {
-    let mut counter = data.counter.lock().unwrap(); // <- get counter's MutexGuard
-    *counter += 1; // <- access counter inside MutexGuard
-
-    format!("Request number: {}", counter) // <- response with count
-}
-// </setup_mutable>
-
-// <make_app_mutable>
-#[actix_rt::main]
-async fn main() -> std::io::Result<()> {
-    let counter = web::Data::new(AppStateWithCounter {
-        counter: Mutex::new(0),
-    });
-
-    HttpServer::new(move || {
-        // move counter into the closure
-        App::new()
-            // Note: using app_data instead of data
-            .app_data(counter.clone()) // <- register the created data
-            .route("/", web::get().to(_index))
-    })
-    .bind("127.0.0.1:8088")?
-    .run()
-    .await
-}
-// </make_app_mutable>
-
 // <start_app>
 #[actix_rt::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/application/src/state.rs
+++ b/examples/application/src/state.rs
@@ -29,7 +29,7 @@ async fn _index(data: web::Data<AppStateWithCounter>) -> String {
 
 // <make_app_mutable>
 #[actix_rt::main]
-async fn _main() -> std::io::Result<()> {
+async fn main() -> std::io::Result<()> {
     let counter = web::Data::new(AppStateWithCounter {
         counter: Mutex::new(0),
     });


### PR DESCRIPTION
The [Shared Mutable State example in docs](https://actix.rs/docs/application/#shared-mutable-state) fails to compile due to the extra "_" at the beginning of the main method:
https://github.com/actix/actix-website/blob/d659d04649eca6ecd02e9c424abe802227c4c636/examples/application/src/state.rs#L32
I think the extra underscore was so `state.rs` would compile. 
This change adds a new mutable_state.rs with code moved from state.rs.
Updates application.md to reference this file instead of state.rs.
Removes un-necessary underscore from "index" function in mutable-state.rs as well.