### PR TITLE
Update method name and link from start() to run()

### DIFF
--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -137,7 +137,7 @@ can change this parameter with the [`HttpServer::shutdown_timeout()`][shutdownti
 method.
 
 You can send a stop message to the server with the server address and specify if you want
-graceful shutdown or not.
+graceful shutdown or not. The [`run()`][runmethod] method returns the address of the server.
 
 `HttpServer` handles several OS signals. *CTRL-C* is available on all OSs, other signals
 are available on unix systems.
@@ -154,6 +154,7 @@ are available on unix systems.
 [bindmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind
 [bindopensslmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_openssl
 [bindrusttls]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_rustls
+[runmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.run
 [workers]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.workers
 [tlsalpn]: https://tools.ietf.org/html/rfc7301
 [exampleopenssl]: https://github.com/actix/examples/blob/master/openssl

--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -137,7 +137,7 @@ can change this parameter with the [`HttpServer::shutdown_timeout()`][shutdownti
 method.
 
 You can send a stop message to the server with the server address and specify if you want
-graceful shutdown or not. The [`start()`][startmethod] method returns the address of the server.
+graceful shutdown or not. The [`addrs()`][addrsmethod] method returns the address of the server.
 
 `HttpServer` handles several OS signals. *CTRL-C* is available on all OSs, other signals
 are available on unix systems.
@@ -154,7 +154,7 @@ are available on unix systems.
 [bindmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind
 [bindopensslmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_openssl
 [bindrusttls]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_rustls
-[startmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.start
+[addrsmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.addrs
 [workers]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.workers
 [tlsalpn]: https://tools.ietf.org/html/rfc7301
 [exampleopenssl]: https://github.com/actix/examples/blob/master/openssl

--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -137,7 +137,7 @@ can change this parameter with the [`HttpServer::shutdown_timeout()`][shutdownti
 method.
 
 You can send a stop message to the server with the server address and specify if you want
-graceful shutdown or not. The [`addrs()`][addrsmethod] method returns the address of the server.
+graceful shutdown or not.
 
 `HttpServer` handles several OS signals. *CTRL-C* is available on all OSs, other signals
 are available on unix systems.
@@ -154,7 +154,6 @@ are available on unix systems.
 [bindmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind
 [bindopensslmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_openssl
 [bindrusttls]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_rustls
-[addrsmethod]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.addrs
 [workers]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.workers
 [tlsalpn]: https://tools.ietf.org/html/rfc7301
 [exampleopenssl]: https://github.com/actix/examples/blob/master/openssl


### PR DESCRIPTION
HttpServer::start() was renamed to run() in https://github.com/actix/actix-web/commit/6a0cd2dced8b085865e966e2d40baf1b8ad9d640, but run() does not return the server address.  It looks like there used to be a spawn() method that worked that way, but now the only way to get the server's address seems to be addrs() or addrs_with_scheme().