### PR TITLE
Update Hugo to 0.79.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.74.2'
+          hugo-version: '0.79.1'
 
       - name: Build
         run: hugo --minify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Use stable
         run: |


### PR DESCRIPTION
This (v0.79.1) contains `chroma` bump which is used as syntax-highlighter by Hugo.

Fixes #197