### PR TITLE
Update examples repo links

### DIFF
--- a/content/docs/application.md
+++ b/content/docs/application.md
@@ -114,7 +114,7 @@ Each [`ServiceConfig`][serviceconfig] can have its own `data`, `routes`, and `se
 <!-- LINKS -->
 
 [usingappprefix]: /docs/url-dispatch/index.html#using-an-application-prefix-to-compose-applications
-[stateexample]: https://github.com/actix/examples/blob/master/state/src/main.rs
+[stateexample]: https://github.com/actix/examples/blob/master/basics/state/src/main.rs
 [guardtrait]: https://docs.rs/actix-web/3/actix_web/guard/trait.Guard.html
 [guardfuncs]: https://docs.rs/actix-web/3/actix_web/guard/index.html#functions
 [guardheader]: https://docs.rs/actix-web/3/actix_web/guard/fn.Header.html

--- a/content/docs/databases.md
+++ b/content/docs/databases.md
@@ -8,9 +8,9 @@ weight: 1010
 
 We have several example projects showing use of async database adapters:
 
-- SQLx: https://github.com/actix/examples/tree/master/sqlx_todo
-- Postgres: https://github.com/actix/examples/tree/master/async_pg
-- SQLite: https://github.com/actix/examples/tree/master/async_db
+- SQLx: https://github.com/actix/examples/tree/master/database_interactions/sqlx_todo
+- Postgres: https://github.com/actix/examples/tree/master/database_interactions/pg
+- SQLite: https://github.com/actix/examples/tree/master/database_interactions/basic
 
 # Diesel
 
@@ -40,7 +40,8 @@ necessary if your return error type implements [`ResponseError`][response-error]
 
 {{< include-example example="databases" file="main.rs" section="index" >}}
 
-That's it! See the full example here: https://github.com/actix/examples/tree/master/diesel
+That's it! See the full example here:
+https://github.com/actix/examples/tree/master/database_interactions/diesel
 
 [web-block]: https://docs.rs/actix-web/3/actix_web/web/fn.block.html
 [response-error]: https://docs.rs/actix-web/3/actix_web/trait.ResponseError.html

--- a/content/docs/http2.md
+++ b/content/docs/http2.md
@@ -33,4 +33,4 @@ connection and tls connection. [rfc section 3.4][rfcsection34].
 [rfcsection34]: https://http2.github.io/http2-spec/#rfc.section.3.4
 [bindopenssl]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_openssl
 [tlsalpn]: https://tools.ietf.org/html/rfc7301
-[examples]: https://github.com/actix/examples/tree/master/rustls
+[examples]: https://github.com/actix/examples/tree/master/security/rustls

--- a/content/docs/request.md
+++ b/content/docs/request.md
@@ -77,10 +77,10 @@ In the following example, we read and print the request payload chunk by chunk:
 
 {{< include-example example="requests" file="streaming.rs" section="streaming" >}}
 
-[examples]: https://github.com/actix/examples/tree/master/json/
+[examples]: https://github.com/actix/examples/tree/master/json/json
 [multipartstruct]: https://docs.rs/actix-multipart/0.2/actix_multipart/struct.Multipart.html
 [fieldstruct]: https://docs.rs/actix-multipart/0.2/actix_multipart/struct.Field.html
-[multipartexample]: https://github.com/actix/examples/tree/master/multipart/
+[multipartexample]: https://github.com/actix/examples/tree/master/forms/multipart
 [urlencoded]: https://docs.rs/actix-web/3/actix_web/dev/struct.UrlEncoded.html
 [payloadextractor]: https://docs.rs/actix-web/3/actix_web/web/struct.Payload.html
 [multipartcrate]: https://crates.io/crates/actix-multipart

--- a/content/docs/server.md
+++ b/content/docs/server.md
@@ -153,6 +153,6 @@ are available on unix systems.
 [bindrusttls]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.bind_rustls
 [workers]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.workers
 [tlsalpn]: https://tools.ietf.org/html/rfc7301
-[exampleopenssl]: https://github.com/actix/examples/blob/master/openssl
+[exampleopenssl]: https://github.com/actix/examples/tree/master/security/openssl
 [shutdowntimeout]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.shutdown_timeout
 [disablesignals]: https://docs.rs/actix-web/3/actix_web/struct.HttpServer.html#method.disable_signals

--- a/content/docs/websockets.md
+++ b/content/docs/websockets.md
@@ -20,5 +20,5 @@ The following is an example of a simple websocket echo server:
 
 [message]: https://docs.rs/actix-web-actors/2/actix_web_actors/ws/enum.Message.html
 [payload]: https://docs.rs/actix-web/3/actix_web/web/struct.Payload.html
-[examples]: https://github.com/actix/examples/tree/master/websocket/
-[chat]: https://github.com/actix/examples/tree/master/websocket-chat/
+[examples]: https://github.com/actix/examples/tree/master/websockets/websocket
+[chat]: https://github.com/actix/examples/tree/master/websockets/chat


### PR DESCRIPTION
The examples repo went through a folder restructuring hence the links changed - hopefully I've covered them all. More info: https://github.com/actix/examples/pull/411