### PR TITLE
Include proper import/use example in testing docs, unit test section.

### DIFF
--- a/examples/testing/src/main.rs
+++ b/examples/testing/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use actix_web::test;
+    use actix_web::{http, test};
 
     #[actix_rt::test]
     async fn test_index_ok() {


### PR DESCRIPTION
importing just `use actix_web::test` throws error at `assert_eq!(resp.status(), http::StatusCode::OK);`:

```
failed to resolve: use of undeclared crate or module `http`
use of undeclared crate or module `http`
```

while it's easy to resolve, and it works due to `http` import in line 4, I believe nonetheless docs should include proper example.
