### PR TITLE
Errors: split code lines to make where logger is wrapped clearer

### DIFF
--- a/examples/errors/src/logging.rs
+++ b/examples/errors/src/logging.rs
@@ -19,15 +19,22 @@ async fn index() -> Result<&'static str, MyError> {
     Err(err)
 }
 
+#[rustfmt::skip]
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     std::env::set_var("RUST_LOG", "my_errors=debug,actix_web=info");
     std::env::set_var("RUST_BACKTRACE", "1");
     env_logger::init();
 
-    HttpServer::new(|| App::new().wrap(Logger::default()).service(index))
-        .bind("127.0.0.1:8080")?
-        .run()
-        .await
+    HttpServer::new(|| {
+        let logger = Logger::default();
+
+        App::new()
+            .wrap(logger)
+            .service(index)
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
 }
 // </logging>


### PR DESCRIPTION
This pull request contains:

- Split code lines in main fn to make where logger is wrapped clearer
- add `#[rustfmt::skip]` the above which rustfmt modifies.
  - following url-dispatch's cfg.rs

Besides, it is almost the same to #216 (closed and could not be reopen).