### PR TITLE
Add example for forcing http/1.1

### DIFF
--- a/content/docs/http1.md
+++ b/content/docs/http1.md
@@ -1,0 +1,22 @@
+---
+title: HTTP/1
+menu: docs_protocols
+weight: 280
+---
+
+For very specific purposes, you may need a server that does not upgrade to H2
+even if the client desires to. In that case you might need to use the H1 service.
+
+# H1 Service
+
+In general, browsers will not use HTTP/2 without HTTPS, that is why the example uses HTTPS.
+
+```toml
+[dependencies]
+actix-cors = "0.5"
+actix-service = "1"
+actix-http = { version = "2", features = ["openssl"] }
+actix-web = { version = "3", features = ["openssl"] }
+openssl = { version = "0.10", features = ["v110"] }
+```
+{{< include-example example="http1" file="main.rs" section="main" >}}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "extractors",
   "flexible-responders",
   "getting-started",
+  "http1",
   "http2",
   "main-example",
   "middleware",

--- a/examples/http1/Cargo.toml
+++ b/examples/http1/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "http1"
+version = "1.0.0"
+edition = "2018"
+
+[dependencies]
+actix-cors = "0.5"
+actix-service = "1"
+actix-http = { version = "2", features = ["openssl"] }
+actix-web = { version = "3", features = ["openssl"] }
+openssl = { version = "0.10", features = ["v110"] }

--- a/examples/http1/src/main.rs
+++ b/examples/http1/src/main.rs
@@ -1,0 +1,47 @@
+// <main>
+use actix_cors::Cors;
+use actix_http::{HttpService, KeepAlive};
+use actix_service::map_config;
+use actix_web::{
+    dev::{AppConfig, Server},
+    web, App, Responder,
+};
+use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+
+async fn h1() -> impl Responder {
+    "H1"
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    println!("Started H1 server: 0.0.0.0:8080");
+
+    Server::build()
+        .backlog(1024)
+        .bind("example", "0.0.0.0:8080", || {
+            let cors = Cors::default()
+                .supports_credentials()
+                .allow_any_origin()
+                .allow_any_method()
+                .allow_any_header();
+            let mut builder =
+                SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
+            builder
+                .set_private_key_file("key.pem", SslFiletype::PEM)
+                .unwrap();
+            builder.set_certificate_chain_file("cert.pem").unwrap();
+            let acceptor = builder.build();
+
+            HttpService::build()
+                .keep_alive(KeepAlive::Os)
+                .client_timeout(0)
+                .h1(map_config(
+                    App::new().wrap(cors).service(web::resource("/").to(h1)),
+                    |_| AppConfig::default(),
+                ))
+                .openssl(acceptor)
+        })?
+        .start()
+        .await
+}
+// </main>


### PR DESCRIPTION
In a recent application, I needed to force HTTP/1.1 on the browser. I ended up asking how to do this on a discord server and this PR puts my solution where I would expect to find it on the docs.

I don't know if this use case is relevant enough to be on the docs or if my wording was adequate, but here it is.