### PR TITLE
fix: correct my_errors log print issue.

### DIFF
--- a/examples/errors/src/logging.rs
+++ b/examples/errors/src/logging.rs
@@ -1,7 +1,7 @@
 // <logging>
 use actix_web::{error, get, middleware::Logger, App, HttpServer, Result};
 use derive_more::{Display, Error};
-use log::debug;
+use log::info;
 
 #[derive(Debug, Display, Error)]
 #[display(fmt = "my error: {}", name)]
@@ -15,14 +15,14 @@ impl error::ResponseError for MyError {}
 #[get("/")]
 async fn index() -> Result<&'static str, MyError> {
     let err = MyError { name: "test error" };
-    debug!(target:"my_errors", "{}", err);
+    info!("{}", err);
     Err(err)
 }
 
 #[rustfmt::skip]
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    std::env::set_var("RUST_LOG", "my_errors=debug,actix_web=info");
+    std::env::set_var("RUST_LOG", "info");
     std::env::set_var("RUST_BACKTRACE", "1");
     env_logger::init();
 

--- a/examples/errors/src/logging.rs
+++ b/examples/errors/src/logging.rs
@@ -15,7 +15,7 @@ impl error::ResponseError for MyError {}
 #[get("/")]
 async fn index() -> Result<&'static str, MyError> {
     let err = MyError { name: "test error" };
-    debug!("{}", err);
+    debug!(target:"my_errors", "{}", err);
     Err(err)
 }
 


### PR DESCRIPTION
Without adding the `target:"my_errors"`, it wouldn't print the error message in the console.
In order to do not let our users misunderstand the usage of the log, I'd like to submit this PR for fixing this issue.
Thanks.
