### PR TITLE
Correct the content-type in the ResponseBiuilder example

### DIFF
--- a/examples/responses/src/main.rs
+++ b/examples/responses/src/main.rs
@@ -11,7 +11,7 @@ use actix_web::HttpResponse;
 
 async fn index() -> HttpResponse {
     HttpResponse::Ok()
-        .content_type("plain/text")
+        .content_type("text/plain")
         .header("X-Hdr", "sample")
         .body("data")
 }


### PR DESCRIPTION
It's text/plain not plain/text