### PR TITLE
Changed middleware examples to a workable state. 

### DIFF
--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -4,8 +4,9 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-actix-web = "3"
-actix-service = "1"
+actix-web = "3.3"
 actix-session = "0.4"
 futures = "0.3"
 env_logger = "0.7"
+# For Token auth middleware example
+sqlx = {version = "0.5", features = ["runtime-actix-rustls", "sqlite"]}


### PR DESCRIPTION
Added an example for transferring data (database pool) to middleware, authorization and connection termination. My English level does not allow me to describe this example well enough to add it to the site.
[The reason for adding this example.](https://stackoverflow.com/questions/57892819/how-to-return-an-early-response-from-an-actix-web-middleware). 
> P.S. The previous comment was quickly made late at night in my sentry.