### PR TITLE
Improve json documentation

### DIFF
--- a/content/docs/request.md
+++ b/content/docs/request.md
@@ -42,13 +42,9 @@ body first and then deserialize the json into an object.
 Actix-web automatically *decompresses* payloads. The following codecs are supported:
 
 * Brotli
-* Chunked
-* Compress
 * Gzip
 * Deflate
-* Identity
-* Trailers
-* EncodingExt
+* Zstd
 
 If request headers contain a `Content-Encoding` header, the request payload is decompressed
 according to the header value. Multiple codecs are not supported, i.e: `Content-Encoding: br, gzip`.

--- a/content/docs/request.md
+++ b/content/docs/request.md
@@ -4,22 +4,6 @@ menu: docs_advanced
 weight: 200
 ---
 
-# Content Encoding
-
-Actix-web automatically *decompresses* payloads. The following codecs are supported:
-
-* Brotli
-* Chunked
-* Compress
-* Gzip
-* Deflate
-* Identity
-* Trailers
-* EncodingExt
-
-If request headers contain a `Content-Encoding` header, the request payload is decompressed
-according to the header value. Multiple codecs are not supported, i.e: `Content-Encoding: br, gzip`.
-
 # JSON Request
 
 There are several options for json body deserialization.
@@ -52,6 +36,22 @@ body first and then deserialize the json into an object.
 {{< include-example example="requests" file="manual.rs" section="json-manual" >}}
 
 > A complete example for both options is available in [examples directory][examples].
+
+# Content Encoding
+
+Actix-web automatically *decompresses* payloads. The following codecs are supported:
+
+* Brotli
+* Chunked
+* Compress
+* Gzip
+* Deflate
+* Identity
+* Trailers
+* EncodingExt
+
+If request headers contain a `Content-Encoding` header, the request payload is decompressed
+according to the header value. Multiple codecs are not supported, i.e: `Content-Encoding: br, gzip`.
 
 # Chunked transfer encoding
 

--- a/content/docs/response.md
+++ b/content/docs/response.md
@@ -18,6 +18,24 @@ instance multiple times, the builder will panic.
 
 {{< include-example example="responses" file="main.rs" section="builder" >}}
 
+# JSON Response
+
+The `Json` type allows to respond with well-formed JSON data: simply return a value of
+type `Json<T>` where `T` is the type of a structure to serialize into *JSON*.
+The type `T` must implement the `Serialize` trait from *serde*.
+
+For the following example to work, you need to add `serde` to your dependencies in `Cargo.toml`:
+
+```toml
+[dependencies]
+serde = "1"
+```
+
+{{< include-example example="responses" file="json_resp.rs" section="json-resp" >}}
+
+Using the `Json` type this way instead of calling the `.json` method on a `HttpResponse` makes it
+immediately clear that the function returns JSON and not any other type of response.
+
 # Content encoding
 
 Actix-web can automatically *compress* payloads with the [*Compress middleware*][compressmidddleware].
@@ -62,14 +80,6 @@ default `ContentEncoding::Auto` is used, which implies automatic content compres
 negotiation.
 
 {{< include-example example="responses" file="auto.rs" section="auto" >}}
-
-# JSON Response
-
-The `Json` type allows to respond with well-formed JSON data: simply return a value of
-type `Json<T>` where `T` is the type of a structure to serialize into *JSON*.
-The type `T` must implement the `Serialize` trait from *serde*.
-
-{{< include-example example="responses" file="json_resp.rs" section="json-resp" >}}
 
 [responsebuilder]: https://docs.rs/actix-web/3/actix_web/dev/struct.HttpResponseBuilder.html
 [compressmidddleware]: https://docs.rs/actix-web/3/actix_web/middleware/struct.Compress.html

--- a/examples/responses/src/json_resp.rs
+++ b/examples/responses/src/json_resp.rs
@@ -1,17 +1,18 @@
 // <json-resp>
-use actix_web::{get, web, HttpResponse, Result};
-use serde::{Deserialize, Serialize};
+use actix_web::{get, web, Result};
+use serde::Serialize;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize)]
 struct MyObj {
     name: String,
 }
 
 #[get("/a/{name}")]
-async fn index(obj: web::Path<MyObj>) -> Result<HttpResponse> {
-    Ok(HttpResponse::Ok().json(MyObj {
-        name: obj.name.to_string(),
-    }))
+async fn index(name: web::Path<String>) -> Result<web::Json<MyObj>> {
+    let obj = MyObj {
+        name: name.to_string(),
+    };
+    Ok(web::Json(obj))
 }
 
 #[actix_web::main]

--- a/examples/responses/src/json_resp.rs
+++ b/examples/responses/src/json_resp.rs
@@ -1,5 +1,5 @@
 // <json-resp>
-use actix_web::{get, web, Result};
+use actix_web::{get, web, Responder, Result};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -8,7 +8,7 @@ struct MyObj {
 }
 
 #[get("/a/{name}")]
-async fn index(name: web::Path<String>) -> Result<web::Json<MyObj>> {
+async fn index(name: web::Path<String>) -> Result<impl Responder> {
     let obj = MyObj {
         name: name.to_string(),
     };


### PR DESCRIPTION
Aims to solve #174 by moving Json sections to the beginning of the Response and Request page. For consistency, the content encoding section now comes after the Json section in both pages.

Additionally, the actual `Json` type is used in the Json response example.