### PR TITLE
Added missing closing </a> and </li> tag

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -151,10 +151,10 @@ let app = App::new()
       </div>
       <div class="col-md-3 actix-feature-selectors">
         <ul>
-          <li class="actix-feature-selector"><a href="#responders">flexible responders</label>
-          <li class="actix-feature-selector"><a href="#extractors">powerful extractors</label>
-          <li class="actix-feature-selector"><a href="#forms">easy form handling</label>
-          <li class="actix-feature-selector"><a href="#routing">request routing</label>
+          <li class="actix-feature-selector"><a href="#responders">flexible responders</a></li>
+          <li class="actix-feature-selector"><a href="#extractors">powerful extractors</a></li>
+          <li class="actix-feature-selector"><a href="#forms">easy form handling</a></li>
+          <li class="actix-feature-selector"><a href="#routing">request routing</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Fixes #228
Both Firefox and Chrome render the list correctly even without the proper closing tags. However it can't hurt to have them in the actual source code. 