### PR TITLE
Improve error handler example

### DIFF
--- a/examples/middleware/src/errorhandler.rs
+++ b/examples/middleware/src/errorhandler.rs
@@ -2,9 +2,9 @@
 
 // <error-handler>
 use actix_web::middleware::errhandlers::{ErrorHandlerResponse, ErrorHandlers};
-use actix_web::{dev, http, HttpResponse, Result};
+use actix_web::{dev, http, web, App, HttpResponse, HttpServer, Result};
 
-fn render_500<B>(mut res: dev::ServiceResponse<B>) -> Result<ErrorHandlerResponse<B>> {
+fn add_error_header<B>(mut res: dev::ServiceResponse<B>) -> Result<ErrorHandlerResponse<B>> {
     res.response_mut().headers_mut().insert(
         http::header::CONTENT_TYPE,
         http::HeaderValue::from_static("Error"),
@@ -14,18 +14,15 @@ fn render_500<B>(mut res: dev::ServiceResponse<B>) -> Result<ErrorHandlerRespons
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    use actix_web::{web, App, HttpServer};
-
     HttpServer::new(|| {
         App::new()
-            .wrap(
-                ErrorHandlers::new()
-                    .handler(http::StatusCode::INTERNAL_SERVER_ERROR, render_500),
-            )
+            .wrap(ErrorHandlers::new().handler(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                add_error_header,
+            ))
             .service(
-                web::resource("/test")
-                    .route(web::get().to(|| HttpResponse::Ok()))
-                    .route(web::head().to(|| HttpResponse::MethodNotAllowed())),
+                web::resource("/")
+                    .route(web::get().to(HttpResponse::InternalServerError)),
             )
     })
     .bind("127.0.0.1:8080")?


### PR DESCRIPTION
**This Commit**
Makes a few changes to the current error handler middleware example:

- renames `render_500` to make it more clear what it does
- changes the handler to return a 500 so the middleware is exercised

**Why?**
I was confused because I was trying to understand this middleware and,
looking at this example, I was wondering under what circumstances the
middleware would trigger. I couldn't tell if it was some magic. I also
couldn't tell what was going on with the extra `head()` route - I
figured that was relevant to the handlers.

After futzing with it a while it seemed to me like we just need to
return an error from the handler that corresponded to the status code
the middleware was looking for so I made that change.