### PR TITLE
Make navbar icon visible in dark mode (mobile)

### DIFF
--- a/static/css/actix.css
+++ b/static/css/actix.css
@@ -753,6 +753,9 @@ span.nc,span.nb {
   color:gold !important;
 }
 
+.navbar-toggler-icon {
+  filter: invert(100%);
+}
 
 }
 


### PR DESCRIPTION
I noticed when going on the website via mobile the hamburger icon was barely readable.

Before:
![Before](https://i.imgur.com/mgDcyFB_d.webp?maxwidth=760&fidelity=grand)
After:
![After](https://i.imgur.com/BIiJfli_d.webp?maxwidth=760&fidelity=grand)
