### PR TITLE
Update logger example

### DIFF
--- a/examples/middleware/src/logger.rs
+++ b/examples/middleware/src/logger.rs
@@ -6,7 +6,7 @@ use env_logger::Env;
 async fn main() -> std::io::Result<()> {
     use actix_web::{App, HttpServer};
 
-    env_logger::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
 
     HttpServer::new(|| {
         App::new()

--- a/examples/middleware/src/logger.rs
+++ b/examples/middleware/src/logger.rs
@@ -6,7 +6,7 @@ use env_logger::Env;
 async fn main() -> std::io::Result<()> {
     use actix_web::{App, HttpServer};
 
-    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::init_from_env(Env::default().default_filter_or("info"));
 
     HttpServer::new(|| {
         App::new()


### PR DESCRIPTION
According to clippy the syntax in this example is deprecated:

```
warning: use of deprecated function `env_logger::from_env`: Prefer `env_logger::Builder::from_env()` instead.
  --> src/main.rs:14:17
   |
14 |     env_logger::from_env(Env::default().default_filter_or("info")).init();
   |                 ^^^^^^^^
   |
```