### PR TITLE
updating cargo.toml for first example

### DIFF
--- a/content/docs/request.md
+++ b/content/docs/request.md
@@ -14,7 +14,7 @@ First example of json of `JSON Request` depends on `serde`:
 
 ```toml
 [dependencies]
-serde = "1"
+serde = { version = "1.0", features = ["derive"] }
 ```
 
 Second example of `JSON Request` depends on `serde` and `serde_json`:


### PR DESCRIPTION
Just started learning rust and actix-web.

I copy and pasted this example and try to run it.

i get this error:

```
error: cannot find derive macro `Deserialize` in this scope
 --> src/main.rs:4:10
  |
4 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^
  |
note: `Deserialize` is imported here, but it is only a trait, without a derive macro
 --> src/main.rs:2:5
  |
2 | use serde::Deserialize;
  |     ^^^^^^^^^^^^^^^^^^

error[E0277]: the trait bound `for<'de> Info: serde::Deserialize<'de>` is not satisfied
   --> src/main.rs:16:58
    |
16  |     HttpServer::new(|| App::new().route("/", web::post().to(index)))
    |                                                          ^^ the trait `for<'de> serde::Deserialize<'de>` is not implemented for `Info`
    |
    = note: required because of the requirements on the impl of `DeserializeOwned` for `Info`
    = note: required because of the requirements on the impl of `FromRequest` for `Json<Info>`
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `FromRequest` for `(Json<Info>,)`
note: required by a bound in `Route::to`
   --> /home/dan/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.0.1/src/route.rs:185:15
    |
185 |         Args: FromRequest + 'static,
    |               ^^^^^^^^^^^ required by this bound in `Route::to`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `json-requests` due to 2 previous errors
dan@functionbox:~/Repos/learn/actix-web/json-requests$ cargo run
   Compiling json-requests v0.1.0 (/home/dan/Repos/learn/actix-web/json-requests)
error: cannot find derive macro `Deserialize` in this scope
 --> src/main.rs:4:10
  |
4 | #[derive(Deserialize)]
  |          ^^^^^^^^^^^
  |
note: `Deserialize` is imported here, but it is only a trait, without a derive macro
 --> src/main.rs:2:5
  |
2 | use serde::Deserialize;
  |     ^^^^^^^^^^^^^^^^^^

error[E0277]: the trait bound `for<'de> Info: serde::Deserialize<'de>` is not satisfied
   --> src/main.rs:16:58
    |
16  |     HttpServer::new(|| App::new().route("/", web::post().to(index)))
    |                                                          ^^ the trait `for<'de> serde::Deserialize<'de>` is not implemented for `Info`
    |
    = note: required because of the requirements on the impl of `DeserializeOwned` for `Info`
    = note: required because of the requirements on the impl of `FromRequest` for `Json<Info>`
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `FromRequest` for `(Json<Info>,)`
note: required by a bound in `Route::to`
   --> /home/dan/.cargo/registry/src/github.com-1ecc6299db9ec823/actix-web-4.0.1/src/route.rs:185:15
    |
185 |         Args: FromRequest + 'static,
    |               ^^^^^^^^^^^ required by this bound in `Route::to`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `json-requests` due to 2 previous errors
```

However the fix for this error is adding this instead in the Cargo.toml file

```toml
serde = { version = "1.0", features = ["derive"] }
```