### PR TITLE
Fix websocket example by bumping version of actix to 0.13

### DIFF
--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -4,6 +4,6 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-actix = "0.12"
+actix = "0.13"
 actix-web = "4"
 actix-web-actors = "4.0.0"


### PR DESCRIPTION
The websocket example failed with:

```
error[E0277]: the trait bound `MyWs: actix::actor::Actor` is not satisfied
   --> websockets/src/main.rs:10:20
    |
10  |     type Context = ws::WebsocketContext<Self>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `actix::actor::Actor` is not implemented for `MyWs`
    |
note: required by a bound in `WebsocketContext`
```

 I don't really understand why, but a version bump of actix from 0.12 to 0.13 seems to fix it. 