### PR TITLE
Simplify cargo watch command

### DIFF
--- a/content/docs/autoreload.md
+++ b/content/docs/autoreload.md
@@ -9,7 +9,7 @@ weight: 1000
 During development it can be very handy to have cargo automatically recompile the code on changes. This can be accomplished very easily by using [`cargo-watch`].
 
 ```sh
-cargo watch -x 'run --bin app'
+cargo watch -x run
 ```
 
 ## Historical Note


### PR DESCRIPTION
`cargo watch -x run` works just as well and it's simpler.