### PR TITLE
Fix Integration Test Example

### DIFF
--- a/examples/testing/src/integration_one.rs
+++ b/examples/testing/src/integration_one.rs
@@ -24,7 +24,7 @@ mod tests {
 
     #[actix_web::test]
     async fn test_index_post() {
-        let app = test::init_service(App::new().route("/", web::get().to(index))).await;
+        let app = test::init_service(App::new().route("/", web::post().to(index))).await;
         let req = test::TestRequest::post().uri("/").to_request();
         let resp = test::call_service(&app, req).await;
         assert!(resp.status().is_client_error());


### PR DESCRIPTION
As titled. We are testing POST so the route that we add should be `post()`.