### PR TITLE
Fix red background on readme

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -21,7 +21,7 @@ cd hello-world
 
 Add `actix-web` as a dependency of your project by adding the following to your `Cargo.toml` file.
 
-```toml
+```
 [dependencies]
 actix-web = "{{< actix-version "actix-web" >}}"
 ```


### PR DESCRIPTION
content/docs/getting-started.md

Initially looked like below:

<img width="901" alt="Screenshot 2022-10-26 at 04 07 03" src="https://user-images.githubusercontent.com/31823892/197913314-0e413e85-8c33-4b4a-bf91-33b9df4006c0.png">
