### PR TITLE
Documentation: extractor page navigation bar is missing sections

### DIFF
--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -46,7 +46,7 @@ The following example limits the size of the payload to 4kb and uses a custom er
 
 <CodeBlock example="extractors" file="json_two.rs" section="json-two" />
 
-# URL-Encoded Forms
+## URL-Encoded Forms
 
 A URL-encoded form body can be extracted to a struct, much like `Json<T>`. This type must implement `serde::Deserialize`.
 
@@ -64,7 +64,7 @@ Actix Web also provides many other extractors, here's a few important ones:
 - [`Bytes`][bytes] - You can convert a request's payload into _Bytes_. [_An example_][bytesexample] is available in the rustdoc.
 - [`Payload`][payload] - Low-level payload extractor primarily for building other extractors. [_An example_][payloadexample] is available in the rustdoc.
 
-# Application State Extractor
+## Application State Extractor
 
 Application state is accessible from the handler with the `web::Data` extractor; however, state is accessible as a read-only reference. If you need mutable access to state, it must be implemented.
 


### PR DESCRIPTION
Hi there,

I wanted to link to the section about url-encoded forms on the [extractor](https://actix.rs/docs/extractors/) page of the documentation. Unfortunately that was impossible, because docusaurus seemingly only adds ids to `h2` headlines. This can also be seen in the page navigation bar on the right:

![actix_extractor_docs_missing_sections](https://user-images.githubusercontent.com/20799702/206866215-dbbd48bb-dd87-4548-a5d2-cfcf40919b8e.png)

Setting the headlines for the url-encoded forms and application state extractor from `h1` to `h2` fixes this, adding ids to the generated HTML and adds the two sections to the page navigation bar (screenshot from my local build of the actix website): 

![actix_extractor_docs_missing_sections_fixed](https://user-images.githubusercontent.com/20799702/206866283-e3161df5-0aaf-42d3-b831-581da6c19c75.png)

It was such a small fix, I didn't bother writing an issue, I hope that's okay.
