### PR TITLE
fix(welcome): broken links

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -13,4 +13,4 @@ The documentation on this website focusses primarily on the Actix Web framework.
 [getting-started]: https://actix.rs/docs/getting-started
 [actix-web-docs]: https://docs.rs/actix-web
 [actix-docs]: https://docs.rs/actix
-[actix-book]: https://actix.rs/docs/actix
+[actix-chapter]: https://actix.rs/docs/actix

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -10,7 +10,7 @@ Actix Web lets you quickly and confidently develop web services in Rust and this
 
 The documentation on this website focusses primarily on the Actix Web framework. For information about the actor framework called Actix, check out the [Actix chapter][actix-chapter] (or the lower level [actix API docs][actix-docs]). Otherwise, head on to the [getting started guide][getting-started]. If you already know your way around and you need specific information you might want to read the [actix-web API docs][actix-web-docs].
 
-[getting-started]: ./getting-started
+[getting-started]: https://actix.rs/docs/getting-started
 [actix-web-docs]: https://docs.rs/actix-web
 [actix-docs]: https://docs.rs/actix
-[actix-book]: ./actix
+[actix-book]: https://actix.rs/docs/actix


### PR DESCRIPTION
### Before
`welcome` can be accessed both through `./docs` and `./docs/welcome`. When trying to navigate from `./docs`, `getting-started` leads to `./getting-started` instead of `./docs/getting-started` => 404.

### Changes
Replaced the relative path with an absolute one to `getting-started` and `actix`. 