### PR TITLE
Fixed keep-alive on response example

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -97,6 +97,7 @@ Actix Web keeps connections open to wait for subsequent requests.
 If the first option above is selected, then keep-alive is enabled for HTTP/1.1 requests if the response does not explicitly disallow it by, for example, setting the [connection type][httpconnectiontype] to `Close` or `Upgrade`. Force closing a connection can be done with [the `force_close()` method on `HttpResponseBuilder`](https://docs.rs/actix-web/4/actix_web/struct.HttpResponseBuilder.html#method.force_close)
 
 > Keep-alive is **off** for HTTP/1.0 and is **on** for HTTP/1.1 and HTTP/2.0.
+
 <CodeBlock example="server" file="keep_alive_tp.rs" section="example" />
 
 ## Graceful shutdown

--- a/examples/server/src/keep_alive_tp.rs
+++ b/examples/server/src/keep_alive_tp.rs
@@ -1,7 +1,9 @@
+#![allow(dead_code)]
+
 // <example>
 use actix_web::{http, HttpRequest, HttpResponse};
 
-async fn index(req: HttpRequest) -> HttpResponse {
+async fn index(_req: HttpRequest) -> HttpResponse {
     let mut resp = HttpResponse::Ok()
         .force_close() // <- Close connection on HttpResponseBuilder
         .finish();

--- a/examples/server/src/keep_alive_tp.rs
+++ b/examples/server/src/keep_alive_tp.rs
@@ -2,10 +2,14 @@
 use actix_web::{http, HttpRequest, HttpResponse};
 
 async fn index(req: HttpRequest) -> HttpResponse {
-    HttpResponse::Ok()
-        .connection_type(http::ConnectionType::Close) // <- Close connection
-        .force_close() // <- Alternative method
-        .finish()
+    let mut resp = HttpResponse::Ok()
+        .force_close() // <- Close connection on HttpResponseBuilder
+        .finish();
+
+    // Alternatively close connection on the HttpResponse struct
+    resp.head_mut().set_connection_type(http::ConnectionType::Close);
+
+    resp
 }
 // </example>
 

--- a/examples/server/src/main.rs
+++ b/examples/server/src/main.rs
@@ -1,4 +1,5 @@
 pub mod keep_alive;
+pub mod keep_alive_tp;
 pub mod signals;
 pub mod ssl;
 pub mod workers;


### PR DESCRIPTION
Fixes #312. I've added the module to the server example's `main.rs` so it is discovered by the CI tests and modified it to make the example compile. I tried to keep the example simple while retaining all the information. <sub>I also enhanced the layout of the documentation by inserting a space between the quote and the example.</sub> I hope you'll like it! 