### PR TITLE
Added warning message for using regex tail matching with `PathBuf` and `NamedFile`

### DIFF
--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -10,6 +10,11 @@ It is possible to serve static files with a custom path pattern and `NamedFile`.
 
 <CodeBlock example="static-files" file="main.rs" section="individual-file" />
 
+:::warning 
+Matching a path tail with the `[.*]` regex and using it to return a `NamedFile` has serious security implications. 
+It offers the possibility for an attacker to insert `../` into the URL and access every file on the host that the user running the server has access to.
+:::
+
 ## Directory
 
 To serve files from specific directories and sub-directories, `Files` can be used. `Files` must be registered with an `App::service()` method, otherwise it will be unable to serve sub-paths.

--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -17,13 +17,13 @@ It offers the possibility for an attacker to insert `../` into the URL and acces
 
 ## Directory
 
-To serve files from specific directories and sub-directories, `Files` can be used. `Files` must be registered with an `App::service()` method, otherwise it will be unable to serve sub-paths.
+To serve files from specific directories and sub-directories, [`Files`][files] can be used. `Files` must be registered with an `App::service()` method, otherwise it will be unable to serve sub-paths.
 
 <CodeBlock example="static-files" file="directory.rs" section="directory" />
 
-By default files listing for sub-directories is disabled. Attempt to load directory listing will return _404 Not Found_ response. To enable files listing, use [_Files::show_files_listing()_][showfileslisting] method.
+By default files listing for sub-directories is disabled. Attempt to load directory listing will return _404 Not Found_ response. To enable files listing, use [`Files::show_files_listing()`][showfileslisting] method.
 
-Instead of showing files listing for directory, it is possible to redirect to a specific index file. Use the [_Files::index_file()_][indexfile] method to configure this redirect.
+Instead of showing files listing for directory, it is possible to redirect to a specific index file. Use the [`Files::index_file()`][indexfile] method to configure this redirect.
 
 ## Configuration
 
@@ -41,5 +41,6 @@ The Configuration can also be applied to directory service:
 
 <CodeBlock example="static-files" file="configuration_two.rs" section="config-two" />
 
-[showfileslisting]: https://docs.rs/actix-files/0.2/actix_files/struct.Files.html
-[indexfile]: https://docs.rs/actix-files/0.2/actix_files/struct.Files.html#method.index_file
+[files]: https://docs.rs/actix-files/0.6/actix_files/struct.Files.html#
+[showfileslisting]: https://docs.rs/actix-files/0.6/actix_files/struct.Files.html#method.show_files_listing
+[indexfile]: https://docs.rs/actix-files/0.6/actix_files/struct.Files.html#method.index_file

--- a/docs/static-files.md
+++ b/docs/static-files.md
@@ -23,7 +23,7 @@ To serve files from specific directories and sub-directories, [`Files`][files] c
 
 By default files listing for sub-directories is disabled. Attempt to load directory listing will return _404 Not Found_ response. To enable files listing, use [`Files::show_files_listing()`][showfileslisting] method.
 
-Instead of showing files listing for directory, it is possible to redirect to a specific index file. Use the [`Files::index_file()`][indexfile] method to configure this redirect.
+Instead of showing files listing for a directory, it is possible to redirect to a specific index file. Use the [`Files::index_file()`][indexfile] method to configure this redirect.
 
 ## Configuration
 


### PR DESCRIPTION
Hopefully fixes #251. I've added a warning message that users should not use regex tail matching with `PathBuf` and `NamedFile` directly, as it allows attackers to inject `../`, possibly gaining access to files in directories that shouldn't be exposed by the server.  

---

I also discovered that the links in the `Directory` section were outdated and wrongly formatted, so I updated them, hope that is okay.