### PR TITLE
Update vhost example to use guard::Host

### DIFF
--- a/docs/application.md
+++ b/docs/application.md
@@ -66,7 +66,7 @@ In the above example, the `show_users` route will have an effective route patter
 
 You can think of a guard as a simple function that accepts a _request_ object reference and returns _true_ or _false_. Formally, a guard is any object that implements the [`Guard`][guardtrait] trait. Actix Web provides several guards. You can check the [functions section][guardfuncs] of the API docs.
 
-One of the provided guards is [`Header`][guardheader]. It can be used as a filter based on request header information.
+One of the provided guards is [`Host`][guardheader]. It can be used as a filter based on request header information.
 
 <CodeBlock example="application" file="vh.rs" section="vh" />
 

--- a/examples/application/src/vh.rs
+++ b/examples/application/src/vh.rs
@@ -7,12 +7,12 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .service(
                 web::scope("/")
-                    .guard(guard::Header("Host", "www.rust-lang.org"))
+                    .guard(guard::Host("www.rust-lang.org"))
                     .route("", web::to(|| async { HttpResponse::Ok().body("www") })),
             )
             .service(
                 web::scope("/")
-                    .guard(guard::Header("Host", "users.rust-lang.org"))
+                    .guard(guard::Host("users.rust-lang.org"))
                     .route("", web::to(|| async { HttpResponse::Ok().body("user") })),
             )
             .route("/", web::to(HttpResponse::Ok))


### PR DESCRIPTION
* Use ```guard::Host``` instead of ```guard::Header```
  * This makes this example code work in both HTTP/1 and HTTP/2 (as there is no "Host" in HTTP/2 headers)