### PR TITLE
Specify size of logo to remove layout shift

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,8 @@ module.exports = {
       logo: {
         alt: 'Actix Logo',
         src: 'img/logo.png',
+        width: 32,
+        height: 32,
       },
       items: [
         {


### PR DESCRIPTION
When navigating by using the main header, docosaurus does a full page rerender (i think, doesn't matter). This makes us redownload the logo each time, and the logo is fairly large (40kb), so it takes some time. Because the size is not specified in the html, this makes the header shift to the side, and then shift back when the image loads.

The size is not specified on the html-markup because size is not specified in config. By specifying the size, html reserves the place for us and avoids this annoying little shift. Docosaurus themselves do this in their docs: https://github.com/facebook/docusaurus/blob/main/website/docusaurus.config.js#L479

You should also just use a smaller image, serving a 720^2 image is not necessary for a 32^2 icon.