### PR TITLE
Respect prefers color scheme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,6 +46,9 @@ module.exports = {
       theme: require('prism-react-renderer/themes/dracula'),
       additionalLanguages: ['rust', 'toml'],
       defaultLanguage: 'rust'
+    },
+    colorMode: {
+      respectPrefersColorScheme: true,
     }
   },
   plugins: ["docusaurus-plugin-sass"],


### PR DESCRIPTION
When i first visited your page, i was met by a white light in the night, even though I use dark mode. This would fix that. This setting yoinked from the way docosaurus does it on their own docs page