### PR TITLE
Add hosting instructions for Shuttle

### DIFF
--- a/docs/shuttle.md
+++ b/docs/shuttle.md
@@ -1,54 +1,43 @@
+---
+title: Hosting on Shuttle
+---
+
+import CodeBlock from '@site/src/components/code_block.js';
+
 # Hosting on Shuttle
 
 <img width="300" src="https://raw.githubusercontent.com/shuttle-hq/shuttle/master/assets/logo-rectangle-transparent.png"/>
 
 > [**Shuttle**](https://www.shuttle.rs) is a Rust-native cloud development platform that lets you deploy your Rust apps for free.
 
-Shuttle has out of the box support for Actix, follow these steps to host your web service on Shuttle:
+Shuttle has out-of-the-box support for Actix Web. Follow these steps to host your web service on Shuttle:
 
 1. Add Shuttle dependencies to `Cargo.toml`:
 
-```toml
-[dependencies]
-shuttle-actix-web = "*"
-shuttle-runtime = "*"
-```
+<CodeBlock example="shuttle" file="manifest" section="shuttle-deps" language="toml" />
 
 2. Add the `#[shuttle_runtime::main]` annotation and update the `main` function as follows:
 
-```rust
-use actix_web::{get, web::ServiceConfig};
-use shuttle_actix_web::ShuttleActixWeb;
-
-#[shuttle_runtime::main]
-async fn main() -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
-    let config = move |cfg: &mut ServiceConfig| {
-        // set up your service here, e.g.:
-        // cfg.service(hello_world);
-    };
-
-    Ok(config.into())
-}
-```
+<CodeBlock example="shuttle" section="shuttle-hello-world" />
 
 3. Install `cargo-shuttle`:
 
-```bash
+```sh
 cargo install cargo-shuttle
 ```
 
 4. Create your project on the Shuttle platform:
 
-```bash
+```sh
 cargo shuttle project start
 ```
 
 5. Deploy! 🚀
 
-```bash
+```sh
 cargo shuttle deploy
 ```
 
 You can run `cargo shuttle run` to test your application locally.
 
-Check out the Actix Web examples [here](https://github.com/shuttle-hq/shuttle-examples/tree/main/actix-web).
+Check out some complete Actix Web examples [here](https://github.com/shuttle-hq/shuttle-examples/tree/main/actix-web).

--- a/docs/shuttle.md
+++ b/docs/shuttle.md
@@ -1,0 +1,54 @@
+# Hosting on Shuttle
+
+<img width="300" src="https://raw.githubusercontent.com/shuttle-hq/shuttle/master/assets/logo-rectangle-transparent.png"/>
+
+> [**Shuttle**](https://www.shuttle.rs) is a Rust-native cloud development platform that lets you deploy your Rust apps for free.
+
+Shuttle has out of the box support for Actix, follow these steps to host your web service on Shuttle:
+
+1. Add Shuttle dependencies to `Cargo.toml`:
+
+```toml
+[dependencies]
+shuttle-actix-web = "*"
+shuttle-runtime = "*"
+```
+
+2. Add the `#[shuttle_runtime::main]` annotation and update the `main` function as follows:
+
+```rust
+use actix_web::{get, web::ServiceConfig};
+use shuttle_actix_web::ShuttleActixWeb;
+
+#[shuttle_runtime::main]
+async fn main() -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
+    let config = move |cfg: &mut ServiceConfig| {
+        // set up your service here, e.g.:
+        // cfg.service(hello_world);
+    };
+
+    Ok(config.into())
+}
+```
+
+3. Install `cargo-shuttle`:
+
+```bash
+cargo install cargo-shuttle
+```
+
+4. Create your project on the Shuttle platform:
+
+```bash
+cargo shuttle project start
+```
+
+5. Deploy! 🚀
+
+```bash
+cargo shuttle deploy
+```
+
+You can run `cargo shuttle run` to test your application locally.
+
+Check out the Actix Web examples [here](https://github.com/shuttle-hq/shuttle-examples/tree/main/actix-web).

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "responder-trait",
   "responses",
   "server",
+  "shuttle",
   "static-files",
   "testing",
   "url-dispatch",

--- a/examples/shuttle/Cargo.toml
+++ b/examples/shuttle/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "shuttle"
+version = "1.0.0"
+edition = "2021"
+
+# <shuttle-deps>
+[dependencies]
+actix-web = "4"
+shuttle-actix-web = "0.30"
+shuttle-runtime = "0.30"
+tokio = "1"
+# </shuttle-deps>

--- a/examples/shuttle/src/main.rs
+++ b/examples/shuttle/src/main.rs
@@ -1,0 +1,19 @@
+#[get("/")]
+async fn hello_world() -> impl actix_web::Responder {
+    "hello world"
+}
+
+// <shuttle-hello-world>
+use actix_web::{get, web::ServiceConfig};
+use shuttle_actix_web::ShuttleActixWeb;
+
+#[shuttle_runtime::main]
+async fn main() -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
+    let config = move |cfg: &mut ServiceConfig| {
+        // set up your service here, e.g.:
+        cfg.service(hello_world);
+    };
+
+    Ok(config.into())
+}
+// </shuttle-hello-world>

--- a/sidebars.js
+++ b/sidebars.js
@@ -18,7 +18,7 @@ module.exports = {
       'static-files',
     ],
     Protocols: ['websockets', 'http2'],
-    Patterns: ['autoreload', 'databases'],
+    Patterns: ['autoreload', 'databases', 'shuttle'],
     Diagrams: ['http_server_init', 'conn_lifecycle'],
     Actix: [
       'actix/sec-0-quick-start',
@@ -29,7 +29,6 @@ module.exports = {
       'actix/sec-5-arbiter',
       'actix/sec-6-sync-arbiter',
     ],
-    Hosting: ['shuttle'],
     'API Documentation': [
       {
         type: 'link',

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ module.exports = {
       'actix/sec-5-arbiter',
       'actix/sec-6-sync-arbiter',
     ],
+    Hosting: ['shuttle'],
     'API Documentation': [
       {
         type: 'link',

--- a/src/components/code_block.js
+++ b/src/components/code_block.js
@@ -1,27 +1,37 @@
 import React, { useState, useEffect } from 'react';
 import RenderCodeBlock from '@theme/CodeBlock';
 
-const CodeBlock = ({ example, file, section }) => {
-    const [code, setCode] = useState("");
+const CodeBlock = ({ example, file, section, language }) => {
+  const [code, setCode] = useState('');
 
-    useEffect(() => {
-        let isMounted = true; 
-        import(`!!raw-loader!@site/examples/${example}/src/${file || "main.rs"}`)
-            .then(source => {
-                source = source
-                    .default
-                    .match(new RegExp(`\/\/ <${section}>\n([\\s\\S]*)\/\/ <\/${section}>`))[1];
-                if (isMounted) setCode(source)
-            })
-            .catch(err => console.log(err));
-        return () => {
-            isMounted = false;
-        }
-    }, [])
+  useEffect(() => {
+    let isMounted = true;
 
-    return (
-        <RenderCodeBlock className="language-rust">{code}</RenderCodeBlock>
-    )
-}
+    const path =
+      file === 'manifest' ? 'Cargo.toml' : `src/${file ?? 'main.rs'}`;
+
+    import(`!!raw-loader!@site/examples/${example}/${path}`)
+      .then((source) => {
+        source = source.default.match(
+          new RegExp(
+            `(?:\/\/|#) <${section}>\n([\\s\\S]*)(?:\/\/|#) <\/${section}>`
+          )
+        )[1];
+
+        if (isMounted) setCode(source);
+      })
+      .catch((err) => console.log(err));
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <RenderCodeBlock className={`language-${language ?? 'rust'}`}>
+      {code}
+    </RenderCodeBlock>
+  );
+};
 
 export default CodeBlock;

--- a/vars.js
+++ b/vars.js
@@ -1,4 +1,5 @@
 module.exports = {
   rustVersion: '1.59',
   actixWebMajorVersion: '4',
+  tokioMajorVersion: '1',
 };


### PR DESCRIPTION
This PR adds a new section to the website called "Hosting" and adds the instructions for creating an Actix Web project on the Shuttle platform.

See https://github.com/shuttle-hq/shuttle-examples/pull/107#issuecomment-1780947281
