### PR TITLE
errors.md: fix type in ResponseError trait

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -12,7 +12,7 @@ If a handler returns an `Error` (referring to the [general Rust trait `std::erro
 
 ```rust
 pub trait ResponseError {
-    fn error_response(&self) -> Response<Body>;
+    fn error_response(&self) -> HttpResponse<BoxBody>;
     fn status_code(&self) -> StatusCode;
 }
 ```


### PR DESCRIPTION
This way it matches the actual types. Source: https://docs.rs/actix-web/latest/actix_web/error/trait.ResponseError.html
The other examples on this page look correct.