### PR TITLE
Fix sec-3-address.md run failed issue

### DIFF
--- a/docs/actix/sec-3-address.md
+++ b/docs/actix/sec-3-address.md
@@ -145,14 +145,14 @@ impl Handler<OrderShipped> for SmsSubscriber {
 
 }
 
-fn main() {
-    let system = System::new("events");
-    let email_subscriber = Subscribe(EmailSubscriber{}.start().recipient());
-    let sms_subscriber = Subscribe(SmsSubscriber{}.start().recipient());
+#[actix::main]
+async fn main() -> Result<(), actix::MailboxError> {
+    let email_subscriber = Subscribe(EmailSubscriber {}.start().recipient());
+    let sms_subscriber = Subscribe(SmsSubscriber {}.start().recipient());
     let order_event = OrderEvents::new().start();
-    order_event.do_send(email_subscriber);
-    order_event.do_send(sms_subscriber);
-    order_event.do_send(Ship(1));
-    system.run();
+    order_event.send(email_subscriber).await?;
+    order_event.send(sms_subscriber).await?;
+    order_event.send(Ship(1)).await?;
+    Ok(())
 }
 ```


### PR DESCRIPTION
The example run failed with below issue
```
`spawn_local` called from outside of a `task::LocalSet`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```