### PR TITLE
fix: sec-3-address.md main should use actix_rt instead of actix

### DIFF
--- a/docs/actix/sec-3-address.md
+++ b/docs/actix/sec-3-address.md
@@ -145,7 +145,7 @@ impl Handler<OrderShipped> for SmsSubscriber {
 
 }
 
-#[actix::main]
+#[actix_rt::main]
 async fn main() -> Result<(), actix::MailboxError> {
     let email_subscriber = Subscribe(EmailSubscriber {}.start().recipient());
     let sms_subscriber = Subscribe(SmsSubscriber {}.start().recipient());


### PR DESCRIPTION
In main func , we should use the `actix_rt::main` instead of `actix::main`