### PR TITLE
Update extractors.md

### DIFF
--- a/docs/extractors.md
+++ b/docs/extractors.md
@@ -64,6 +64,8 @@ Actix Web also provides many other extractors, here's a few important ones:
 - [`Bytes`][bytes] - You can convert a request's payload into _Bytes_. [_An example_][bytesexample] is available in the rustdoc.
 - [`Payload`][payload] - Low-level payload extractor primarily for building other extractors. [_An example_][payloadexample] is available in the rustdoc.
 
+Note: You can't use the String in combination with the Json extractor
+
 ## Application State Extractor
 
 Application state is accessible from the handler with the `web::Data` extractor; however, state is accessible as a read-only reference. If you need mutable access to state, it must be implemented.


### PR DESCRIPTION
Summary: String, Payload and Bytes extractors don't work properly when the Json extractor is present.

I noticed I can't use String and Json extractors and I think this should be stated in the documentation, because I spent hours on my code thinking that I had a bug. I needed the raw string and also the Json Value (serde_json::Value) and just wanted the handler to handle the serialization. Everything worked fine, until I tried to do an hmac hash and realized my hashes were wrong. This was caused because the order of the request body's json was not preserved, so I was looking for different ways to get the raw String. When I used the String as an extractor, I get an empty string, so I assumed it wasn't working and I went down a rabbit hole of trying to find a solution. I finally found out that the String extractor works but without the Json extractor present, and the Payload and Bytes extractors also displayed similar behaviour. This would have been helpful if it wasn't on the documentation