### PR TITLE
Added documentation for `from_fn` and `wrap` in middleware page

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -115,5 +115,5 @@ You can use the `ErrorHandlers::handler()` method to register a custom error han
 [servicetrait]: https://docs.rs/actix-web/4/actix_web/dev/trait.Service.html
 [transformtrait]: https://docs.rs/actix-web/4/actix_web/dev/trait.Transform.html
 [wrap_fn]: https://docs.rs/actix-web/4/actix_web/struct.App.html#method.wrap_fn
-[from_fn]: https://docs.rs/actix-web/latest/actix_web/middleware/fn.from_fn.html
-[wrap]: https://docs.rs/actix-web/4.9.0/actix_web/struct.App.html#method.wrap
+[from_fn]: https://docs.rs/actix-web/4/actix_web/middleware/fn.from_fn.html
+[wrap]: https://docs.rs/actix-web/4/actix_web/struct.App.html#method.wrap

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -27,6 +27,10 @@ Alternatively, for simple use cases, you can use [_wrap_fn_][wrap_fn] to create 
 
 <CodeBlock example="middleware" file="wrap_fn.rs" section="wrap-fn" />
 
+You can also use [_from_fn_][from_fn] to in combination with [_wrap_][wrap] to create a function as middlware.
+
+<CodeBlock example="middleware" file="from_fn.rs" section="from-fn" />
+
 > Actix Web provides several useful middleware, such as _logging_, _user sessions_, _compress_, etc.
 
 **Warning: if you use `wrap()` or `wrap_fn()` multiple times, the last occurrence will be executed first.**
@@ -111,3 +115,5 @@ You can use the `ErrorHandlers::handler()` method to register a custom error han
 [servicetrait]: https://docs.rs/actix-web/4/actix_web/dev/trait.Service.html
 [transformtrait]: https://docs.rs/actix-web/4/actix_web/dev/trait.Transform.html
 [wrap_fn]: https://docs.rs/actix-web/4/actix_web/struct.App.html#method.wrap_fn
+[from_fn]: https://docs.rs/actix-web/latest/actix_web/middleware/fn.from_fn.html
+[wrap]: https://docs.rs/actix-web/4.9.0/actix_web/struct.App.html#method.wrap

--- a/examples/middleware/src/from_fn.rs
+++ b/examples/middleware/src/from_fn.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code, unused_variables)]
+
+// <from-fn>
+use actix_web::{
+    body::MessageBody,
+    dev::{ServiceRequest, ServiceResponse},
+    middleware::{from_fn, Next},
+    App, Error,
+};
+
+async fn my_midleware(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    // pre-processing
+    next.call(req).await
+    // post-processing
+}
+
+#[actix_web::main]
+async fn main() {
+    let app = App::new().wrap(from_fn(my_midleware));
+}
+// </from-fn>

--- a/examples/middleware/src/main.rs
+++ b/examples/middleware/src/main.rs
@@ -1,5 +1,6 @@
 pub mod default_headers;
 pub mod errorhandler;
+pub mod from_fn;
 pub mod logger;
 pub mod user_sessions;
 pub mod wrap_fn;


### PR DESCRIPTION
I added a small section to include the new `from_fn` added in 4.9.0.

Here is what the rendered docs look like:

![image](https://github.com/user-attachments/assets/283086fa-6b6f-41e3-b31b-b05216f28600)
