### PR TITLE
docs: update Shuttle deployment docs

### DIFF
--- a/docs/shuttle.md
+++ b/docs/shuttle.md
@@ -26,10 +26,10 @@ Shuttle has out-of-the-box support for Actix Web. Follow these steps to host you
 cargo install cargo-shuttle
 ```
 
-4. Create your project on the Shuttle platform:
+4. Login to Shuttle
 
 ```sh
-shuttle project start
+shuttle login
 ```
 
 5. Deploy! 🚀


### PR DESCRIPTION
Hey! Just a quick patch to update the Shuttle deployment docs to include the login step, and to reflect that the `project start` command is no longer needed.