### PR TITLE
docs(examples): use `web::ThinData` rather than `web::Data` for SeaORM

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -44,7 +44,7 @@ Next, set up the database connection as part of your application state. SeaORM m
 
 <CodeBlock example="sea-orm-databases" file="main.rs" section="main" />
 
-In your request handler, use the `web::Data<DatabaseConnection>` extractor to get the database connection and perform async operations directly:
+In your request handler, use the `web::ThinData<DatabaseConnection>` extractor to get the database connection and perform async operations directly:
 
 <CodeBlock example="sea-orm-databases" file="main.rs" section="index" />
 

--- a/examples/sea-orm-databases/src/main.rs
+++ b/examples/sea-orm-databases/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> io::Result<()> {
 
     HttpServer::new(move || {
         App::new()
-            .app_data(web::Data::new(conn.clone()))
+            .app_data(web::ThinData(conn.clone()))
             .route("/{name}", web::get().to(index))
     })
     .bind(("127.0.0.1", 8080))?
@@ -60,7 +60,7 @@ async fn main() -> io::Result<()> {
 
 // <index>
 async fn index(
-    conn: web::Data<DatabaseConnection>,
+    conn: web::ThinData<DatabaseConnection>,
     name: web::Path<(String,)>,
 ) -> actix_web::Result<impl Responder> {
     let (name,) = name.into_inner();


### PR DESCRIPTION
AFAIK `sea_orm::DatabaseConnection` is already using `Arc` internally for some types or hold no data for others, so no need to wrap it around `Arc` again?