### PR TITLE
docs: Fix actor address retrieval example using send().await

### DIFF
--- a/docs/actix/sec-4-context.md
+++ b/docs/actix/sec-4-context.md
@@ -56,7 +56,8 @@ impl Handler<WhoAmI> for MyActor {
     }
 }
 
-let who_addr = addr.do_send(WhoAmI{});
+let addr = MyActor.start();
+let who_addr = addr.send(WhoAmI {}).await;
 ```
 
 [`Context::address()`]: https://docs.rs/actix/latest/actix/struct.Context.html#method.address


### PR DESCRIPTION
This PR updates the documentation example for retrieving an actor's address via Context::address() to ensure the code functions as described and compiles correctly.

Changes made:

Replaced do_send with send().await: The previous example used addr.do_send(WhoAmI{}). Because do_send fires off a message blindly and ignores the response, who_addr would not actually capture the requested address. Updating this to addr.send(WhoAmI {}).await correctly awaits the Future and captures the returned actix::Addr<MyActor>.

Added Actor initialization: Included let addr = MyActor.start(); before the message is sent. In the previous snippet, addr was used without being defined, which could confuse readers trying to implement the example.